### PR TITLE
Remove a deprecated call that's no longer available in BouncyCastle

### DIFF
--- a/jsignpdf-itxt/src/core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
+++ b/jsignpdf-itxt/src/core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
@@ -320,7 +320,7 @@ public class PdfPublicKeySecurityHandler {
             new IssuerAndSerialNumber(
                 tbscertificatestructure.getIssuer(), 
                 tbscertificatestructure.getSerialNumber().getValue());
-        Cipher cipher = Cipher.getInstance(algorithmidentifier.getObjectId().getId());        
+        Cipher cipher = Cipher.getInstance(algorithmidentifier.getAlgorithm().getId());        
         cipher.init(1, x509certificate);
         DEROctetString deroctetstring = new DEROctetString(cipher.doFinal(abyte0));
         RecipientIdentifier recipId = new RecipientIdentifier(issuerandserialnumber);

--- a/src/net/sf/jsignpdf/SignerOptionsFromCmdLine.java
+++ b/src/net/sf/jsignpdf/SignerOptionsFromCmdLine.java
@@ -161,16 +161,28 @@ public class SignerOptionsFromCmdLine extends BasicSignerOptions {
 			setRightPrinting(line.getOptionValue(ARG_RIGHT_PRINT));
 		if (line.hasOption(ARG_DISABLE_COPY_LONG))
 			setRightCopy(false);
+        else
+			setRightCopy(true);
 		if (line.hasOption(ARG_DISABLE_ASSEMBLY_LONG))
 			setRightAssembly(false);
+        else
+			setRightAssembly(true);
 		if (line.hasOption(ARG_DISABLE_FILL_LONG))
 			setRightFillIn(false);
+        else
+			setRightFillIn(true);
 		if (line.hasOption(ARG_DISABLE_SCREEN_READERS_LONG))
 			setRightScreanReaders(false);
+        else
+			setRightScreanReaders(true);
 		if (line.hasOption(ARG_DISABLE_MODIFY_ANNOT_LONG))
 			setRightModifyAnnotations(false);
+        else
+			setRightModifyAnnotations(true);
 		if (line.hasOption(ARG_DISABLE_MODIFY_CONTENT_LONG))
 			setRightModifyContents(false);
+        else
+			setRightModifyContents(true);
 
 		// visible signature
 		if (line.hasOption(ARG_VISIBLE))


### PR DESCRIPTION
getObjectId is deprecated in org.bouncycastle.asn1.x509.AlgorithmIdentifier

http://javadox.com/org.bouncycastle/bcprov-jdk15on/1.49/org/bouncycastle/asn1/x509/AlgorithmIdentifier.html#getObjectId()

Without the change, I couldn't compile on OS X:
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)
