### PR TITLE
Remove a deprecated call that's no longer available in BouncyCastle

### DIFF
--- a/jsignpdf-itxt/src/core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
+++ b/jsignpdf-itxt/src/core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
@@ -320,7 +320,7 @@ public class PdfPublicKeySecurityHandler {
             new IssuerAndSerialNumber(
                 tbscertificatestructure.getIssuer(), 
                 tbscertificatestructure.getSerialNumber().getValue());
-        Cipher cipher = Cipher.getInstance(algorithmidentifier.getObjectId().getId());        
+        Cipher cipher = Cipher.getInstance(algorithmidentifier.getAlgorithm().getId());        
         cipher.init(1, x509certificate);
         DEROctetString deroctetstring = new DEROctetString(cipher.doFinal(abyte0));
         RecipientIdentifier recipId = new RecipientIdentifier(issuerandserialnumber);


### PR DESCRIPTION
Resolves a compile error seen when building on Mac OS X / Java 1.8.0_121-b13