### PR TITLE
Support signing using PDF signatures (depends on upstream openpdf changes)

### DIFF
--- a/jsignpdf/src/main/java/net/sf/jsignpdf/SignerLogic.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/SignerLogic.java
@@ -272,9 +272,15 @@ public class SignerLogic implements Runnable {
                 final String tmpImgPath = options.getImgPath();
                 if (tmpImgPath != null) {
                     LOGGER.info(RES.get("console.createImage", tmpImgPath));
-                    final Image img = Image.getInstance(tmpImgPath);
-                    LOGGER.info(RES.get("console.setSignatureGraphic"));
-                    sap.setSignatureGraphic(img);
+                    if (tmpImgPath.endsWith(".pdf")) {
+                        PdfReader sigreader = new PdfReader(tmpImgPath);
+                        LOGGER.info(RES.get("console.setSignatureGraphic"));
+                        sap.setSignaturePDF(sigreader, 1);
+                    } else {
+                        final Image img = Image.getInstance(tmpImgPath);
+                        LOGGER.info(RES.get("console.setSignatureGraphic"));
+                        sap.setSignatureGraphic(img);
+                    }
                 }
                 final String tmpBgImgPath = options.getBgImgPath();
                 if (tmpBgImgPath != null) {
@@ -319,7 +325,7 @@ public class SignerLogic implements Runnable {
                 sap.setLayer4Text(options.getL4Text());
                 LOGGER.info(RES.get("console.setRender"));
                 RenderMode renderMode = options.getRenderMode();
-                if (renderMode == RenderMode.GRAPHIC_AND_DESCRIPTION && sap.getSignatureGraphic() == null) {
+                if (renderMode == RenderMode.GRAPHIC_AND_DESCRIPTION && !sap.hasValidSignatureGraphic()) {
                     LOGGER.warning(
                             "Render mode of visible signature is set to GRAPHIC_AND_DESCRIPTION, but no image is loaded. Fallback to DESCRIPTION_ONLY.");
                     LOGGER.info(RES.get("console.renderModeFallback"));


### PR DESCRIPTION
Currently, vector images (svg, pdf) cannot be used as signature graphic. Related issue: #183 

I proposed changes to the upstream openpdf (https://github.com/LibrePDF/OpenPDF/pull/1181) to support PDF as a visible signature.

This PR includes changes to jsignpdf that make use of that new feature. However, maven decides that jsignpdf should depend on a pretty old version (1.3.30) of openpdf on my end, which complicated the testing of this new feature.

I have tested in two different setups:
1. jsignpdf + openpdf 1.3.30
2. jsignpdf + openpdf master (2.0.3)

For case 1, this PR contains all jsignpdf changes. However my openpdf PR (https://github.com/LibrePDF/OpenPDF/pull/1181) is not compatible with 1.3.30 (https://github.com/LibrePDF/OpenPDF/tree/1.3.30). Instead, please apply the following patch to openpdf 1.3.30:

[v1.3.30-Support-using-PDF-in-addition-to-images-as-the-signa.patch.txt](https://github.com/user-attachments/files/15855554/v1.3.30-Support-using-PDF-in-addition-to-images-as-the-signa.patch.txt)

For case 2, the openpdf PR contains all necessary changes. However, the current jsignpdf is not compatible with the latest openpdf. Please apply the following patch **on top of** this jsignpdf PR:

[For-testing-purpose-adapt-jsignpdf-to-openpdf-2.0.3.patch.txt](https://github.com/user-attachments/files/15855588/For-testing-purpose-adapt-jsignpdf-to-openpdf-2.0.3.patch.txt)


PS: if you want to use svg signatures, it is very easy to convert them to PDF: `inkscape in.svg --export-type=pdf -o out.pdf`