### PR TITLE
Bouncy castle update

### DIFF
--- a/.github/workflows/refresh-flatpak-deps.yml
+++ b/.github/workflows/refresh-flatpak-deps.yml
@@ -1,0 +1,65 @@
+name: Refresh Flatpak maven-dependencies
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'pom.xml'
+      - '**/pom.xml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-flatpak-deps
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Install Flatpak + Flathub remote
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y flatpak
+        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+    - name: Install Flatpak SDK + openjdk21 extension
+      run: |
+        sudo flatpak install -y --noninteractive flathub \
+          org.freedesktop.Sdk//25.08 \
+          org.freedesktop.Sdk.Extension.openjdk21//25.08
+
+    - name: Regenerate maven-dependencies.json
+      run: ./distribution/linux/flatpak/generate-dependencies.sh
+
+    - name: Open self-healing PR on drift
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        base: master
+        branch: chore/flatpak-deps-refresh
+        delete-branch: true
+        add-paths: distribution/linux/flatpak/maven-dependencies.json
+        commit-message: |
+          chore(flatpak): regenerate maven-dependencies.json
+        title: "chore(flatpak): refresh maven-dependencies.json"
+        body: |
+          Automated refresh of `distribution/linux/flatpak/maven-dependencies.json`.
+
+          The `refresh-flatpak-deps` workflow detected drift after a change to a
+          `pom.xml` on `master` and regenerated the offline Maven manifest used by
+          the Devel Flatpak build.
+
+          Safe to merge once review passes. If the regeneration itself is broken,
+          the fix belongs in `distribution/linux/flatpak/generate-dependencies.sh`.
+
+          **Note:** CI does not run automatically on PRs opened by `GITHUB_TOKEN`.
+          Close and reopen this PR, or push any commit to its branch, to trigger
+          the usual `pr-builder` / `codeql-analysis` workflows. Upgrading this job
+          to a PAT or GitHub App token would remove that limitation.

--- a/jsignpdf/pom.xml
+++ b/jsignpdf/pom.xml
@@ -192,11 +192,11 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <maven.dependency.plugin.version>3.10.0</maven.dependency.plugin.version>
         <maven.shade.plugin.version>3.6.2</maven.shade.plugin.version>
 
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
         <jsign.pkcs11.version>1.1.0</jsign.pkcs11.version>
         <jsign.jpedal.version>4.92.13</jsign.jpedal.version>
         <pdfbox.version>2.0.27</pdfbox.version>
@@ -49,12 +49,12 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- Migrate BouncyCastle from the retired `bcprov-jdk15on` / `bcpkix-jdk15on` 1.70 artifacts to the maintained `bcprov-jdk18on` / `bcpkix-jdk18on` line at 1.84. Unblocks Dependabot security updates, which were failing because no non-vulnerable version of `bcprov-jdk15on` exists (the artifact was retired at 1.70; fixes land on `-jdk18on` 1.78+). Java package names are identical across both artifact lines, so no source changes are needed.
- Add a self-healing `refresh-flatpak-deps` workflow. On every push to `master` that touches a `pom.xml`, it reinstalls the Flathub `org.freedesktop.Sdk//25.08` + `openjdk21` extension, re-runs `distribution/linux/flatpak/generate-dependencies.sh`, and — only if drift is detected — opens a PR on `chore/flatpak-deps-refresh` via `peter-evans/create-pull-request` (pinned to v8.1.1 SHA). Keeps the offline Flatpak manifest in sync without maintainer ceremony, without pushing directly to `master`.

## Test plan
- [x] `mvn -pl jsignpdf -am test` — 81 tests pass locally after the BC swap.
- [ ] CI green on this PR.
- [ ] After merge, confirm the next Dependabot security run on `org.bouncycastle:*` succeeds instead of aborting.
- [ ] After merge, confirm `refresh-flatpak-deps` runs (the BC coordinate change is itself a POM change) and opens a PR with the regenerated `maven-dependencies.json` pointing at `bcprov-jdk18on` / `bcpkix-jdk18on` / `bcutil-jdk18on` 1.84.

## Operational notes for `refresh-flatpak-deps`
- Requires **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests**, otherwise the action fails with 403.
- CI does not auto-run on PRs opened by `GITHUB_TOKEN` (GitHub blocks this to prevent recursion). Workarounds: push any commit to the self-healing branch, close-and-reopen the PR, or swap the token to a PAT/GitHub App later.
- `concurrency: cancel-in-progress: true` so rapid successive POM pushes only regenerate once.