### PR TITLE
Migrate to OpenPdf 3 (and Java 21)

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Java and credentials
       uses: actions/setup-java@v5
       with:
-        java-version: 11
+        java-version: 21
         distribution: 'temurin'
         server-id: ossrh
         server-username: MAVEN_USERNAME

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 8
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/.github/workflows/push-snapshots.yaml
+++ b/.github/workflows/push-snapshots.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Java and credentials
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 JSignPdf is a Java application for adding digital signatures to PDF documents. It provides both a GUI (JavaFX default, Swing fallback via `-Djsignpdf.swing=true`) and a CLI interface.
 
-- **Java**: 11+
+- **Java**: 21+
 - **Build**: Apache Maven multi-module
 - **Repository**: https://github.com/intoolswetrust/jsignpdf
 
@@ -86,6 +86,6 @@ GUI (JavaFX / Swing)            ──┘         (model)              (signing 
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `pr-builder.yaml` | PR/push to master | `mvn verify` with Java 11 |
+| `pr-builder.yaml` | PR/push to master | `mvn verify` with Java 21 |
 | `push-snapshots.yaml` | Push to master | Deploy SNAPSHOTs to Maven Central |
 | `do-release.yml` | Manual dispatch | Full release |

--- a/design-doc/3.0.0-java21-upgrade.md
+++ b/design-doc/3.0.0-java21-upgrade.md
@@ -1,0 +1,249 @@
+# Java 21 + OpenPDF 3.x upgrade plan for JSignPdf 3.0.0
+
+Status: proposal
+Target release: 3.0.0 (next Beta → GA)
+Scope: compile / runtime baseline, dependencies, and code modernization
+
+## 1. Context
+
+The 3.0.0 release already ships with:
+
+- JavaFX GUI as default, Swing fallback via `-Djsignpdf.swing=true`
+- Bouncy Castle upgraded to 1.84
+- jpackage-based Windows installer (built on JDK 21 in CI)
+- Flatpak runtime on `org.freedesktop.Sdk.Extension.openjdk21`
+
+So runtime is already Java 21 in the two paths that ship a bundled JRE (jpackage + Flatpak). The remaining blockers are the compile baseline and a few dev-only workflows still pinned to Java 11.
+
+Since a further Beta is planned before the GA cut, we have a shake-out window big enough to land the full Java-21-and-OpenPDF-3.x migration in one go rather than deferring it to a later major.
+
+**This plan supersedes the "stay on OpenPDF 1.4.2 / defer to post-3.0.0" recommendation in [`3.0.0-openpdf-upgrade.md`](./3.0.0-openpdf-upgrade.md).** That doc's §7 (follow-up) is now in scope for 3.0.0. The pdf2image cascade cleanup in its §3 and §5 still stands unchanged.
+
+## 2. Scope
+
+Three phases, all inside 3.0.0:
+
+- **Phase 1** — Lift the compile baseline and CI matrix to Java 21.
+- **Phase 2** — Upgrade OpenPDF to 3.x, add `openpdf-renderer`, verify the rest of the dep tree on 21.
+- **Phase 3** — Targeted code modernization to Java 21 native syntax.
+
+Phase 4 is verification and Phase 5 is the release sequence (Beta → GA).
+
+## 3. Phase 1 — Baseline
+
+All changes are mechanical and land as one PR.
+
+### 3.1 Root `pom.xml`
+
+```diff
+-        <maven.compiler.release>11</maven.compiler.release>
++        <maven.compiler.release>21</maven.compiler.release>
+```
+
+Release-profile enforcer:
+
+```diff
+-                                        <requireJavaVersion>
+-                                            <version>[11,12)</version>
+-                                        </requireJavaVersion>
++                                        <requireJavaVersion>
++                                            <version>[21,22)</version>
++                                        </requireJavaVersion>
+```
+
+### 3.2 GitHub Actions workflows
+
+- `.github/workflows/pr-builder.yaml` — `java-version: 11` → `21`
+- `.github/workflows/push-snapshots.yaml` — `java-version: 11` → `21`
+- `.github/workflows/do-release.yml` line 43 (the compile/stage step) — `java-version: 11` → `21`
+- The jpackage step at line 110 already uses `java-version: 21`; leave untouched.
+
+### 3.3 JavaFX
+
+In `jsignpdf/pom.xml`:
+
+```diff
+-        <openjfx.version>17.0.15</openjfx.version>
++        <openjfx.version>21.0.x</openjfx.version>   <!-- pin to the latest 21 LTS patch -->
+```
+
+And bump `openjfx-monocle` (currently `11.0.2`) to a JavaFX-21-compatible version. The `org.testfx` coordinate publishes `openjfx-monocle` versions aligned with the JavaFX line; pick the 21.x equivalent.
+
+### 3.4 Docs
+
+- `README.md`, `AGENTS.md`: "Java 11+" → "Java 21+".
+- `website/` sections mentioning runtime requirements.
+- 3.0.0 release notes: make the Java 21 runtime requirement a headline item. The jpackage and Flatpak bundles are unaffected (they already carry a Java 21 runtime); the plain ZIP distribution now requires the user to have a Java 21 JRE on `PATH`.
+
+### 3.5 Non-changes
+
+- Flatpak manifests (`distribution/linux/flatpak/*.yaml`, `generate-dependencies.sh`) already target `openjdk21`. No change.
+- Windows installer PowerShell (`distribution/windows/build-windows-installers.ps1`) already runs on JDK 17+. No change.
+- No `module-info.java` exists in any module; JPMS stays unused. No change.
+
+## 4. Phase 2 — Dependencies
+
+### 4.1 OpenPDF 1.3.30 → 3.0.x
+
+Details from [`3.0.0-openpdf-upgrade.md` §2.2](./3.0.0-openpdf-upgrade.md) still apply. Concrete actions:
+
+1. Bump `openpdf.version` to the latest 3.0.x (currently **3.0.3**).
+2. Rename imports across ~8 files in `jsignpdf/src/main/java/net/sf/jsignpdf/`:
+   - `SignerLogic`, `PdfUtils`, `FontUtils`, `PdfExtraInfo`, `UncompressPdf`, `preview/Pdf2Image`, `types/PdfVersion`, `types/CertificationLevel` (plus any others flagged by compile).
+   - Mechanical: `com.lowagie.` → `org.openpdf.`.
+3. Audit any `char`-typed PDF-version argument. JSignPdf currently references `PdfWriter.VERSION_*` constants via `types/PdfVersion` — likely a no-op, but confirm against the 3.0.3 Javadoc.
+4. Regression-test the **PDF-2.0-default** behavior change:
+   - `PdfStamper.createSignature(..., append=true)` preserves source version — verify with an existing-signature append test.
+   - Fresh metadata: verify the resulting document validates in Adobe Reader, Foxit, and a mobile viewer.
+   - LTV verification with TSA + OCSP + CRL still produces an LTV-enabled signature recognized by Adobe.
+5. Bouncy Castle: OpenPDF 3.0.x ships with BC 1.83; JSignPdf declares BC 1.84 directly. Nearest-wins resolution picks 1.84; 1.83/1.84 are binary-compatible. No conflict.
+
+### 4.2 pdf2image cascade
+
+Per [`3.0.0-openpdf-upgrade.md` §3 / §5](./3.0.0-openpdf-upgrade.md):
+
+- Remove `com.github.rjolly:pdf-renderer` (dead Sun Labs 2007 fork), its `PDF2IMAGE_PDFRENDERER` constant, the `getImageUsingPdfRenderer` method in `preview/Pdf2Image.java`, and its entry in `distribution/linux/flatpak/maven-dependencies.json`.
+- Bump `pdfbox.version` 2.0.27 → 2.0.36. (A separate PDFBox 3.x migration is orthogonal and deferred.)
+
+### 4.3 Add `openpdf-renderer`
+
+Now unblocked because we're on Java 21.
+
+In root `pom.xml` `<dependencyManagement>` and `jsignpdf/pom.xml`:
+
+```xml
+<dependency>
+    <groupId>com.github.librepdf</groupId>
+    <artifactId>openpdf-renderer</artifactId>
+    <version>${openpdf.version}</version>   <!-- 3.0.3; same train as openpdf-core -->
+</dependency>
+```
+
+In `Constants.java`:
+
+```diff
+-    public static final String PDF2IMAGE_JPEDAL = "jpedal";
+-    public static final String PDF2IMAGE_PDFBOX = "pdfbox";
+-    public static final String PDF2IMAGE_LIBRARIES_DEFAULT = PDF2IMAGE_JPEDAL + "," + PDF2IMAGE_PDFBOX;
++    public static final String PDF2IMAGE_JPEDAL = "jpedal";
++    public static final String PDF2IMAGE_PDFBOX = "pdfbox";
++    public static final String PDF2IMAGE_OPENPDF = "openpdf";
++    public static final String PDF2IMAGE_LIBRARIES_DEFAULT =
++            PDF2IMAGE_JPEDAL + "," + PDF2IMAGE_PDFBOX + "," + PDF2IMAGE_OPENPDF;
+```
+
+In `preview/Pdf2Image.java`:
+
+- Add a `getImageUsingOpenPdfRenderer(int aPage)` method that returns `BufferedImage` or `null`.
+- Add the matching branch in `getImageForPage`.
+- `openpdf-renderer` is the actively-maintained descendant of the Sun Labs PDFRenderer lineage we just removed, so it slots in as a drop-in successor. Keep it as the tertiary fallback; PDFBox stays primary for general-purpose correctness.
+
+### 4.4 Dependency audit
+
+| Dependency | Pinned | Java 21 status | Action |
+|---|---|---|---|
+| Bouncy Castle | 1.84 | ok | none |
+| commons-cli | 1.11.0 | ok | none |
+| commons-lang3 | 3.20.0 | ok | none |
+| commons-io | 2.21.0 | ok | none |
+| JUnit 4 | 4.13.2 | ok on 21 | keep for 3.0.0; JUnit 5 migration is a separate task |
+| jsign-pkcs11 | 1.1.0 | ok | smoke-test against a hardware token |
+| **jsign-jpedal** | 4.92.13 | **verify** | see 4.5 |
+| PDFBox | 2.0.27 → 2.0.36 | ok | bumped in 4.2 |
+
+### 4.5 jsign-jpedal fork (`com.github.kwart.jsign:jsign-jpedal:4.92.13`)
+
+This one needs active attention — the codebase derives from 2011-era JPedal LGPL and may use reflection patterns that trip `--illegal-access` or touch internal `sun.*` APIs on Java 21.
+
+Action:
+
+1. Run `mvn verify` on JDK 21 and capture any warnings from `Pdf2Image#getImageUsingJPedal` execution paths (both the test suite and a manual preview render on a sample PDF).
+2. If warnings or failures surface, cut a new `jsign-jpedal` release with the fixes, bump `jsign.jpedal.version` in root `pom.xml`.
+3. If no warnings surface, pin-and-ship as-is.
+
+## 5. Phase 3 — Code modernization
+
+Land as **separate small PRs, one theme per PR** — review surface stays small and any regression bisects cleanly.
+
+### 5.1 Mechanical wins (single-theme PRs)
+
+- **`stream().toList()`** in place of `collect(Collectors.toList())`. ~17 call sites across 9 files (`SignerFileChooser`, `SignPdfForm`, `SignerOptionsFromCmdLine`, `ssl/DynamicX509TrustManager`, `crl/CRLInfo`, `extcsp/CloudFoxy`, `utils/KeyStoreUtils`, `utils/ResourceProvider`, `utils/ConvertUtils`).
+- **`var`** for obvious locals — targeted, not wholesale. Good candidates: try-with-resources declarations, newly-constructed DTOs, stream pipeline heads. Skip where the explicit type carries real documentation value (public API boundaries, `BasicSignerOptions` fields).
+- **Pattern matching for `instanceof`** — three hits (`fx/view/MainWindowController`, `fx/view/CertificateSettingsController`, `SignPdfForm`). Drop the explicit casts.
+- **Enhanced `switch` expressions** — `preview/Pdf2Image#getImageForPage` dispatch over `Constants.PDF2IMAGE_*` converts cleanly to a switch expression once the cascade also includes `openpdf`.
+
+### 5.2 Structural changes (judgment calls)
+
+- **Text blocks** for multi-line strings — scan for embedded XML/FXML bootstraps and the CLI help text emitted by `SignerOptionsFromCmdLine`. Only worth it where the string is long enough to read better as a block.
+- **Records** — candidates only in the `types/` package and any preview-cache value types. **Do not** convert `BasicSignerOptions` — it's a mutable JavaBean with property-change listeners, and both the Swing UI and the JavaFX ViewModels depend on that mutability. Any record conversion should be obviously free of observers.
+- **Sealed types** — no clear fit. The `types/` package is already enums, which give exhaustiveness without a seal.
+
+### 5.3 Don't adopt
+
+- **Virtual threads** — signing is single-document CPU work, not I/O-concurrent; BC signing operations aren't interruptible cleanly. Potential future niche: parallel page rendering in a multi-page preview, but that's a feature, not a modernization.
+- **Foreign Function & Memory API / Vector API** — no use case here; all native interop goes through JCA providers / PKCS#11 via `jsign-pkcs11`.
+
+### 5.4 Free gains (no code change)
+
+- Helpful NullPointerExceptions (JDK 14+) — on by default on 21. Error messages in crash logs become significantly more actionable. Call this out in release notes.
+- G1 / ZGC improvements — no tuning needed for a desktop signing tool, just a note.
+
+## 6. Phase 4 — Verification
+
+### 6.1 Pre-flight
+
+- `mvn clean verify` on JDK 21 (Temurin) locally — must be green before any CI change merges.
+- `mvn dependency:tree -Denforcer.skip=false` — catch any transitive surprise from the OpenPDF 3.x train.
+
+### 6.2 Signing smoke-test matrix
+
+- CLI signing (base case, TSA, OCSP, CRL, visible sig, PDF/A-2, existing-sig append).
+- JavaFX GUI: open, preview, drag-place signature, sign, verify.
+- Swing fallback (`-Djsignpdf.swing=true`) — same flows.
+- PKCS#11 hardware token signing (via `jsign-pkcs11`).
+- LTV verification against Adobe Reader, Foxit, and one mobile viewer.
+
+### 6.3 Preview cascade
+
+Exercise each backend individually by restricting `pdf2image.libraries`:
+
+- `jpedal` only — confirms the fork still works on Java 21.
+- `pdfbox` only.
+- `openpdf` only — confirms the new backend wiring.
+
+### 6.4 UI test suite
+
+`fx/FxTranslationsTest` runs headless via Monocle. Ensure the `openjfx-monocle` bump resolves; test argLine already sets `-Dglass.platform=Monocle -Dmonocle.platform=Headless -Dprism.order=sw`.
+
+### 6.5 Distribution builds
+
+- Flatpak: `distribution/linux/flatpak/generate-dependencies.sh` then a local `flatpak-builder` run.
+- Windows: `distribution/windows/build-windows-installers.ps1` on a Windows box with JDK 21 + WiX 3.x.
+- ZIP: `mvn package` output under `distribution/target/`.
+
+## 7. Phase 5 — Release sequencing
+
+The 3.0.0 release train already has several Betas behind it (latest: `3.0.0-BETA-4`). The next Beta absorbs this migration:
+
+1. Land Phase 1 (baseline) and Phase 2 (deps) together in **`3.0.0-BETA-5`**. This is the high-risk change; Beta users shake out regressions.
+2. Land Phase 3 (modernization) in a follow-up Beta or directly in GA, once Phase 1+2 is proven stable. Modernization is internal-only so it's low-risk, but separating commits keeps bisection trivial.
+3. Cut **`3.0.0` GA** once at least one Beta cycle reports clean on Phase 1+2.
+
+If Phase 1+2 shows signing regressions that can't be fixed in-Beta, the fallback is to revert Phase 1+2 (`git revert`) and ship 3.0.0 as originally scoped, promoting this plan back to a 3.1.0 target.
+
+## 8. Risks & mitigations
+
+- **JPedal fork under Java 21**: highest risk because the upstream code is ~15 years old. Mitigation: Phase 2 explicitly budgets a cut-a-new-fork-release option (§4.5). Worst case, drop `jpedal` from the default cascade — PDFBox + openpdf-renderer cover the fallback.
+- **OpenPDF 3.x PDF-2.0-default**: could produce output that older viewers mis-render. Mitigation: explicit regression matrix (§4.1 step 4). If problematic, force PDF version back to 1.7 at write time via `PdfStamper`/`PdfWriter` — one-line change.
+- **Plain-ZIP users stuck on Java 11**: hard break. Mitigation: release notes, prominent download-page banner, and the fact that `3.0.0-BETA-*` already signaled the major cut. The jpackage + Flatpak bundled paths are unaffected.
+- **JavaFX 21 ABI vs 17 FXML**: FXML files don't depend on ABI changes; Monocle is the more likely friction point. Mitigation: run `FxTranslationsTest` against each candidate `openjfx-monocle` version.
+- **Reflective access in transitive deps**: Java 21 removed some historical escape hatches (Security Manager deprecated-for-removal, etc.). Mitigation: `mvn verify` with default flags (no `--add-opens`) must pass; if any dep needs opens, prefer upgrading the dep over adding the flag.
+
+## 9. Out of scope for 3.0.0
+
+Explicitly deferred to a later release:
+
+- PDFBox 2.x → 3.x (separate API migration; the 2.0.x line is still supported on Java 21).
+- JUnit 4 → 5 (tooling modernization, orthogonal).
+- JPMS / `module-info.java` adoption (large ripple; low benefit for a desktop app).
+- GraalVM native-image packaging (requires reflection config work; big scope).

--- a/design-doc/3.0.0-openpdf-upgrade.md
+++ b/design-doc/3.0.0-openpdf-upgrade.md
@@ -1,0 +1,166 @@
+# OpenPDF upgrade & pdf2image cleanup for JSignPdf 3.0.0
+
+Status: proposal
+Target release: 3.0.0
+Scope: PDF engine (OpenPDF) and preview rendering backends (`pdf2image.libraries`)
+
+## 1. Context
+
+JSignPdf currently uses:
+
+| Dependency | Coordinate | Pinned |
+|---|---|---|
+| OpenPDF | `com.github.librepdf:openpdf` | `1.3.30` |
+| PDFBox | `org.apache.pdfbox:pdfbox` | `2.0.27` |
+| Sun PDF Renderer (rjolly) | `com.github.rjolly:pdf-renderer` | `140` |
+| JPedal LGPL (our fork) | `com.github.kwart.jsign:jsign-jpedal` | `4.92.13` |
+
+- Java baseline: **11** (`<maven.compiler.release>11</maven.compiler.release>` in the root pom).
+- Bouncy Castle was just bumped to `1.84` (`bcprov-jdk18on` / `bcpkix-jdk18on`).
+- OpenPDF is the signing engine; the other three are alternate preview-rendering backends cascaded through `net.sf.jsignpdf.preview.Pdf2Image`, configurable via the `pdf2image.libraries` property (default `jpedal,pdfbox,pdfrenderer`).
+
+## 2. OpenPDF 1.x → 3.x: should we upgrade?
+
+### 2.1 Upstream state
+
+| Line | Latest | Java required | Package | BC |
+|---|---|---|---|---|
+| 1.3.x | 1.3.43 (2024-03-30) | 8 | `com.lowagie` | ~1.77 |
+| 1.4.x | 1.4.2  (2024-04-01) | **11** | `com.lowagie` | ~1.77 |
+| 2.0.x | 2.0.5  (2025-05-26) | **17** | `com.lowagie` | 1.80 |
+| 2.1–2.2.x | 2.2.5 (2026-03-09) | **21** | `com.lowagie` (legacy) + `org.openpdf` (modern, from 2.4.0) | 1.81 |
+| 3.0.x | **3.0.3** (2026-03-09) | **21** | `org.openpdf` **only** | 1.83 |
+
+Maven coordinate is still `com.github.librepdf:openpdf` in 3.0.x; groupId did not change. 1.3.x / 1.4.x are effectively dormant; active development is on 3.x.
+
+### 2.2 Breaking changes relevant to JSignPdf
+
+- **Package rename** `com.lowagie.*` → `org.openpdf.*`, enforced in 3.0.0 (no legacy module available any more). Mechanical sed across ~8 files in `jsignpdf/src/main/java/net/sf/jsignpdf/` (`SignerLogic`, `PdfUtils`, `FontUtils`, `PdfExtraInfo`, `UncompressPdf`, `preview/Pdf2Image`, `types/PdfVersion`, `types/CertificationLevel`, etc.).
+- **Signing API surface is preserved**: `PdfReader`, `PdfStamper`, `PdfSignatureAppearance`, `PdfSignature`, `TSAClientBouncyCastle`, `OcspClientBouncyCastle`, `PdfPKCS7`, `AcroFields`, `BaseFont`, `FontFactory`, `PdfName`, `PdfDictionary`, `PdfString`, `PdfDate`, `PdfWriter` all still exist in `org.openpdf.text.pdf` in 3.0.3.
+- **`PdfWriter.setPdfVersion` et al. changed `char` → `String`.** JSignPdf only references the `VERSION_*` constants (via `types/PdfVersion`), so likely unaffected — but worth a quick check.
+- **Default PDF version flipped to 2.0.** For appended signatures (`PdfStamper.createSignature(..., append=true)`) the source document's version is preserved, so existing signed output shouldn't regress — but freshly generated metadata and any code path that relies on the default needs regression testing against Adobe Reader / Foxit / mobile viewers, and against LTV verification.
+- **Bouncy Castle**: OpenPDF 3.x ships with BC 1.83; JSignPdf runs BC 1.84. Maven resolves nearest-wins (JSignPdf's direct 1.84 declaration wins), and BC 1.83/1.84 are binary-compatible. No conflict.
+- **License**: unchanged (LGPL-2.1 OR MPL-2.0).
+
+### 2.3 The blocker: Java baseline
+
+**Every OpenPDF ≥ 2.0.0 drops Java 11.** The smallest version that runs on our Java 11 baseline is **1.4.2**.
+
+Going to any 2.x / 3.x release requires JSignPdf to raise its own baseline to Java 21 first — a product-level decision bigger than the OpenPDF bump itself. That's reasonable to plan for the *next* major after 3.0.0, but not for 3.0.0 where the theme is consolidation (BC upgrade, JavaFX GUI, jpackage installer).
+
+### 2.4 Recommendation
+
+**Do not upgrade OpenPDF to 2.x or 3.x in 3.0.0.** Bump to **1.4.2** instead.
+
+- 1.4.2 stays on `com.lowagie`, Java 11 compatible → drop-in replacement for 1.3.30.
+- Picks up the last round of 1.x bug fixes without any migration work.
+- Defers the package-rename + Java-21 + PDF-2.0-default migration to a dedicated future release where it can be tested properly.
+
+Skip 2.x entirely when we do migrate: 2.4.0+ also sits on `org.openpdf` and also requires Java 21, so going 1.x → 2.x → 3.x buys nothing. Go straight 1.4.2 → 3.x in one hop once Java 21 is adopted.
+
+## 3. Review of current `pdf2image.libraries`
+
+### 3.1 JPedal LGPL — `com.github.kwart.jsign:jsign-jpedal:4.92.13`
+
+- Upstream (IDRSolutions) discontinued the open-source LGPL fork in ~2011.
+- The `kwart/jsign-jpedal` repo is a fork maintained by the JSignPdf author specifically for this project. Effectively under our control.
+- Runs on Java 11. No known blocker.
+- **Verdict: keep.** It's our own fork; we set the upkeep policy. Still the highest-fidelity renderer for many scanned/legacy documents in practice.
+
+### 3.2 Apache PDFBox — `org.apache.pdfbox:pdfbox:2.0.27`
+
+- PDFBox 2.0.x is still actively maintained alongside 3.0.x. Latest 2.0.x at the time of writing is around **2.0.36**; latest 3.x is **3.0.7**.
+- 2.0.27 is ~9 patch versions behind — worth bumping for CVE/bugfix coverage.
+- 3.0.x requires API migration (renderer, loader, and signature APIs moved); out of scope for 3.0.0.
+- **Verdict: bump** `pdfbox.version` from `2.0.27` to the latest `2.0.x` (currently 2.0.36). 3.x migration deferred.
+
+### 3.3 Sun PDF Renderer (rjolly fork) — `com.github.rjolly:pdf-renderer:140`
+
+- A thin re-packaging of the Sun Labs `com.sun.pdfview` code from 2007. The rjolly fork has only a handful of commits and no meaningful activity in years.
+- Supports a subset of PDF 1.4 only. Fails silently on any modern PDF feature.
+- Effectively orphaned upstream.
+- **Verdict: remove** from `pdf2image.libraries` defaults and from the pom. PDFBox 2.0.x covers the same fallback niche with far better coverage.
+
+## 4. Should we add `openpdf-renderer`?
+
+- Coordinate: `com.github.librepdf:openpdf-renderer`, latest **3.0.3** (lives as a module inside the `LibrePDF/OpenPDF` monorepo, released on the same train as the core).
+- Pure-Java PDF → `BufferedImage` renderer. API shape slots cleanly into our `Pdf2Image` cascade (`int page + owner password → BufferedImage`).
+- **Interestingly, it descends from the same Sun Labs PDFRenderer 2007 codebase as the rjolly `pdf-renderer` we currently ship — so adopting it is effectively replacing the dead rjolly fork with the actively-maintained LibrePDF successor.**
+- But: because it's part of the OpenPDF 3.x release train, it **requires Java 21** and pairs with OpenPDF 3.x. Same blocker as §2.3.
+
+**Verdict: do not add in 3.0.0.** Add it as the successor to rjolly/pdf-renderer in the same future release where we raise the Java baseline to 21 and upgrade OpenPDF to 3.x. At that point:
+
+- Add constant `Constants.PDF2IMAGE_OPENPDF` = `"openpdf"`.
+- Default fallback order becomes `jpedal,pdfbox,openpdf` (openpdf-renderer as tertiary fallback — PDFBox is still the most capable general-purpose renderer).
+- Remove the rjolly dependency; `openpdf-renderer` is its modern descendant.
+
+## 5. Action plan for 3.0.0
+
+Changes are all small and independent; can land in one PR.
+
+### 5.1 `pom.xml` (root)
+
+```diff
+-        <pdfbox.version>2.0.27</pdfbox.version>
+-        <pdf-renderer.version>140</pdf-renderer.version>
++        <pdfbox.version>2.0.36</pdfbox.version>
+         ...
+-        <openpdf.version>1.3.30</openpdf.version>
++        <openpdf.version>1.4.2</openpdf.version>
+```
+
+Remove the `com.github.rjolly:pdf-renderer` entry from `<dependencyManagement>`.
+
+### 5.2 `jsignpdf/pom.xml`
+
+Remove the `<dependency>` on `com.github.rjolly:pdf-renderer`.
+
+### 5.3 `jsignpdf/src/main/java/net/sf/jsignpdf/Constants.java`
+
+```diff
+-    public static final String PDF2IMAGE_JPEDAL = "jpedal";
+-    public static final String PDF2IMAGE_PDFBOX = "pdfbox";
+-    public static final String PDF2IMAGE_PDFRENDERER = "pdfrenderer";
+-    public static final String PDF2IMAGE_LIBRARIES_DEFAULT = PDF2IMAGE_JPEDAL + "," + PDF2IMAGE_PDFBOX + ","
+-            + PDF2IMAGE_PDFRENDERER;
++    public static final String PDF2IMAGE_JPEDAL = "jpedal";
++    public static final String PDF2IMAGE_PDFBOX = "pdfbox";
++    public static final String PDF2IMAGE_LIBRARIES_DEFAULT = PDF2IMAGE_JPEDAL + "," + PDF2IMAGE_PDFBOX;
+```
+
+### 5.4 `jsignpdf/src/main/java/net/sf/jsignpdf/preview/Pdf2Image.java`
+
+- Remove the `getImageUsingPdfRenderer` method and its branch in `getImageForPage`.
+- Remove imports `com.sun.pdfview.PDFFile`, `com.sun.pdfview.PDFPage`, `com.sun.pdfview.PDFParseException`, `com.sun.pdfview.decrypt.PDFPassword`, and the now-unused `java.nio.*` / `java.io.RandomAccessFile` imports.
+
+### 5.5 Flatpak / distribution manifests
+
+- `distribution/linux/flatpak/maven-dependencies.json` contains a pinned entry for `com.github.rjolly/pdf-renderer/140` — drop it and bump the pdfbox entry. Regenerate if there is a script; otherwise hand-edit.
+
+### 5.6 Docs / properties
+
+- `sample.properties`: if it documents `pdf2image.libraries`, update the example to `jpedal,pdfbox`.
+- `website/`: any page that lists the rendering backends.
+
+### 5.7 Tests
+
+- Run `mvn clean verify` with Java 11 — nothing else should move.
+- Sanity-check signing: CLI signing, GUI signing, and the preview cascade (disable jpedal/pdfbox in turn to confirm the remaining backends still render).
+
+## 6. Risks
+
+- **OpenPDF 1.3.30 → 1.4.2**: very low risk (same package, same Java baseline, same BC). Still worth running the full signing test suite plus a smoke test against a PDF/A document and a PDF with an existing signature (append mode).
+- **PDFBox 2.0.27 → 2.0.36**: low risk; 2.0.x has held API compatibility. Preview code uses only `PDDocument.load` and `PDFRenderer.renderImageWithDPI`, both stable.
+- **Removing rjolly/pdf-renderer**: user-visible if anyone explicitly sets `pdf2image.libraries=pdfrenderer` in `conf/conf.properties` or on the CLI. We should call this out in the 3.0.0 release notes — the token will be silently ignored after the change (the cascade skips unknown names).
+
+## 7. Follow-up (post-3.0.0)
+
+Tracked as a separate initiative, *not* part of 3.0.0:
+
+1. Raise Java baseline to **21** (root pom `maven.compiler.release`, CI matrix, jpackage runtime image, Flatpak runtime).
+2. Upgrade OpenPDF **1.4.2 → 3.0.x** in one hop:
+   - Package rename `com.lowagie.*` → `org.openpdf.*`.
+   - Audit any `char`-based PDF-version calls.
+   - Regression-test PDF 2.0 default output against Adobe Reader, Foxit, mobile viewers, and LTV verification.
+3. Add **`openpdf-renderer`** as a `pdf2image.libraries` backend (constant `PDF2IMAGE_OPENPDF`), default order `jpedal,pdfbox,openpdf`.
+4. Consider PDFBox 2.x → 3.x migration at the same time (separate API migration; orthogonal to the OpenPDF move).

--- a/distribution/doc/release-notes/3.0.0.md
+++ b/distribution/doc/release-notes/3.0.0.md
@@ -18,7 +18,10 @@ packaging.
   supported (Temurin no longer ships 32-bit JDKs); 32-bit and
   Linux/macOS users can still use the cross-arch `jsignpdf-<VERSION>.zip`
   with their own JRE.
-- **Java 11 is now the minimum** runtime.
+- **Java 21 is now the minimum** runtime. The jpackage Windows
+  installers and the Flatpak bundle ship their own Java 21 runtime, so
+  they are unaffected; users of the platform-independent
+  `jsignpdf-<VERSION>.zip` now need a Java 21 (or newer) JRE on `PATH`.
 
 ## Other changes
 

--- a/distribution/linux/flatpak/maven-dependencies.json
+++ b/distribution/linux/flatpak/maven-dependencies.json
@@ -351,27 +351,6 @@
   },
   {
     "type": "file",
-    "url": "https://repo1.maven.org/maven2/com/github/rjolly/pdf-renderer/140/pdf-renderer-140-sources.jar",
-    "sha256": "e677c07d078941b3bd10b23dac9e54936a2986933011df1b5cdc428f264d3c20",
-    "dest": "m2local/com/github/rjolly/pdf-renderer/140",
-    "dest-filename": "pdf-renderer-140-sources.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo1.maven.org/maven2/com/github/rjolly/pdf-renderer/140/pdf-renderer-140.jar",
-    "sha256": "77eadd97f27109e34b4b02fe17b0b161315a5498c8563cc711c35f7a8ece96cc",
-    "dest": "m2local/com/github/rjolly/pdf-renderer/140",
-    "dest-filename": "pdf-renderer-140.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo1.maven.org/maven2/com/github/rjolly/pdf-renderer/140/pdf-renderer-140.pom",
-    "sha256": "2e8c5be0f02385904874955f3218f9e13104d7d565134629b0eb8557f7a00b66",
-    "dest": "m2local/com/github/rjolly/pdf-renderer/140",
-    "dest-filename": "pdf-renderer-140.pom"
-  },
-  {
-    "type": "file",
     "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
     "sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     "dest": "m2local/com/google/code/findbugs/jsr305/3.0.2",

--- a/jsignpdf/pom.xml
+++ b/jsignpdf/pom.xml
@@ -191,6 +191,10 @@
             <artifactId>openpdf</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.librepdf</groupId>
+            <artifactId>openpdf-renderer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
@@ -209,10 +213,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.rjolly</groupId>
-            <artifactId>pdf-renderer</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>

--- a/jsignpdf/pom.xml
+++ b/jsignpdf/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>openjfx-monocle</artifactId>
-            <version>11.0.2</version>
+            <version>21.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/Constants.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/Constants.java
@@ -133,9 +133,9 @@ public class Constants {
 
     public static final String PDF2IMAGE_JPEDAL = "jpedal";
     public static final String PDF2IMAGE_PDFBOX = "pdfbox";
-    public static final String PDF2IMAGE_PDFRENDERER = "pdfrenderer";
+    public static final String PDF2IMAGE_OPENPDF = "openpdf";
     public static final String PDF2IMAGE_LIBRARIES_DEFAULT = PDF2IMAGE_JPEDAL + "," + PDF2IMAGE_PDFBOX + ","
-            + PDF2IMAGE_PDFRENDERER;
+            + PDF2IMAGE_OPENPDF;
     public static final String PDF2IMAGE_LIBRARIES = ConfigProvider.getInstance().getNotEmptyProperty("pdf2image.libraries",
             PDF2IMAGE_LIBRARIES_DEFAULT);
 

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/PdfExtraInfo.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/PdfExtraInfo.java
@@ -32,9 +32,9 @@ package net.sf.jsignpdf;
 import net.sf.jsignpdf.types.PageInfo;
 import net.sf.jsignpdf.utils.PdfUtils;
 
-import com.lowagie.text.Rectangle;
-import com.lowagie.text.exceptions.BadPasswordException;
-import com.lowagie.text.pdf.PdfReader;
+import org.openpdf.text.Rectangle;
+import org.openpdf.text.exceptions.BadPasswordException;
+import org.openpdf.text.pdf.PdfReader;
 
 /**
  * Provides additional information for selected input PDF file.

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/SignerLogic.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/SignerLogic.java
@@ -70,22 +70,22 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 
-import com.lowagie.text.Font;
-import com.lowagie.text.Image;
-import com.lowagie.text.Rectangle;
-import com.lowagie.text.pdf.AcroFields;
-import com.lowagie.text.pdf.OcspClientBouncyCastle;
-import com.lowagie.text.pdf.PdfDate;
-import com.lowagie.text.pdf.PdfDictionary;
-import com.lowagie.text.pdf.PdfName;
-import com.lowagie.text.pdf.PdfPKCS7;
-import com.lowagie.text.pdf.PdfReader;
-import com.lowagie.text.pdf.PdfSignature;
-import com.lowagie.text.pdf.PdfSignatureAppearance;
-import com.lowagie.text.pdf.PdfStamper;
-import com.lowagie.text.pdf.PdfString;
-import com.lowagie.text.pdf.PdfWriter;
-import com.lowagie.text.pdf.TSAClientBouncyCastle;
+import org.openpdf.text.Font;
+import org.openpdf.text.Image;
+import org.openpdf.text.Rectangle;
+import org.openpdf.text.pdf.AcroFields;
+import org.openpdf.text.pdf.OcspClientBouncyCastle;
+import org.openpdf.text.pdf.PdfDate;
+import org.openpdf.text.pdf.PdfDictionary;
+import org.openpdf.text.pdf.PdfName;
+import org.openpdf.text.pdf.PdfPKCS7;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.PdfSignature;
+import org.openpdf.text.pdf.PdfSignatureAppearance;
+import org.openpdf.text.pdf.PdfStamper;
+import org.openpdf.text.pdf.PdfString;
+import org.openpdf.text.pdf.PdfWriter;
+import org.openpdf.text.pdf.TSAClientBouncyCastle;
 
 /**
  * Main logic of signer application. It uses iText to create signature in PDF.
@@ -184,10 +184,10 @@ public class SignerLogic implements Runnable {
             final HashAlgorithm hashAlgorithm = options.getHashAlgorithmX();
 
             LOGGER.info(RES.get("console.createSignature"));
-            char tmpPdfVersion = '\0'; // default version - the same as input
-            char inputPdfVersion = reader.getPdfVersion();
-            char requiredPdfVersionForGivenHash = hashAlgorithm.getPdfVersion().getCharVersion();
-            if (inputPdfVersion < requiredPdfVersionForGivenHash) {
+            String tmpPdfVersion = null; // default version - the same as input
+            String inputPdfVersion = reader.getPdfVersion();
+            String requiredPdfVersionForGivenHash = hashAlgorithm.getPdfVersion().getStringVersion();
+            if (inputPdfVersion != null && inputPdfVersion.compareTo(requiredPdfVersionForGivenHash) < 0) {
                 // this covers also problems with visible signatures (embedded
                 // fonts) in PDF 1.2, because the minimal version
                 // for hash algorithms is 1.3 (for SHA1)
@@ -196,13 +196,13 @@ public class SignerLogic implements Runnable {
                     // then return false (not possible)
                     LOGGER.info(RES.get("console.updateVersionNotPossibleInAppendModeForGivenHash",
                             hashAlgorithm.getAlgorithmName(), hashAlgorithm.getPdfVersion().getVersionName(),
-                            PdfVersion.fromCharVersion(inputPdfVersion).getVersionName(),
+                            PdfVersion.fromStringVersion(inputPdfVersion).getVersionName(),
                             HashAlgorithm.valuesWithPdfVersionAsString()));
                     return false;
                 }
                 tmpPdfVersion = requiredPdfVersionForGivenHash;
                 LOGGER.info(RES.get("console.updateVersion",
-                        new String[] { String.valueOf(inputPdfVersion), String.valueOf(tmpPdfVersion) }));
+                        new String[] { inputPdfVersion, tmpPdfVersion }));
             }
 
             final PdfStamper stp = PdfStamper.createSignature(reader, fout, tmpPdfVersion, null, options.isAppendX());
@@ -211,7 +211,7 @@ public class SignerLogic implements Runnable {
                 // (otherwise we're getting to troubles)
                 final AcroFields acroFields = stp.getAcroFields();
                 @SuppressWarnings("unchecked")
-                final List<String> sigNames = acroFields.getSignatureNames();
+                final List<String> sigNames = acroFields.getSignedFieldNames();
                 for (String sigName : sigNames) {
                     acroFields.removeField(sigName);
                 }
@@ -303,7 +303,7 @@ public class SignerLogic implements Runnable {
                     signer = options.getSignerName();
                 }
                 final String certificate = PdfPKCS7.getSubjectFields((X509Certificate) chain[0]).toString();
-                final String timestamp = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss z").format(sap.getSignDate().getTime());
+                final String timestamp = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss z").format(sap.getSignDateNullSafe().getTime());
                 if (options.getL2Text() != null) {
                     final Map<String, String> replacements = new HashMap<String, String>();
                     replacements.put(L2TEXT_PLACEHOLDER_SIGNER, StringUtils.defaultString(signer));
@@ -358,7 +358,7 @@ public class SignerLogic implements Runnable {
             if (!StringUtils.isEmpty(contact)) {
                 dic.setContact(sap.getContact());
             }
-            dic.setDate(new PdfDate(sap.getSignDate()));
+            dic.setDate(new PdfDate(sap.getSignDateNullSafe()));
             sap.setCryptoDictionary(dic);
 
             final Proxy tmpProxy = options.createProxy();

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/UncompressPdf.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/UncompressPdf.java
@@ -32,10 +32,10 @@ package net.sf.jsignpdf;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import com.lowagie.text.Document;
-import com.lowagie.text.DocumentException;
-import com.lowagie.text.pdf.PdfReader;
-import com.lowagie.text.pdf.PdfStamper;
+import org.openpdf.text.Document;
+import org.openpdf.text.DocumentException;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.PdfStamper;
 
 /**
  * Simple small programm to uncompress PDFs.
@@ -65,7 +65,7 @@ public class UncompressPdf {
             System.out.println("Uncompressing " + tmpFile + " to " + newFileName);
             try {
                 PdfReader reader = new PdfReader(tmpFile);
-                PdfStamper stamper = new PdfStamper(reader, new FileOutputStream(newFileName), '\0');
+                PdfStamper stamper = new PdfStamper(reader, new FileOutputStream(newFileName), (String) null);
                 int total = reader.getNumberOfPages() + 1;
                 for (int i = 1; i < total; i++) {
                     reader.setPageContent(i, reader.getPageContent(i));

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/fx/view/MainWindowController.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/fx/view/MainWindowController.java
@@ -35,7 +35,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
-import com.lowagie.text.exceptions.BadPasswordException;
+import org.openpdf.text.exceptions.BadPasswordException;
 
 import net.sf.jsignpdf.BasicSignerOptions;
 import net.sf.jsignpdf.Constants;

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/preview/Pdf2Image.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/preview/Pdf2Image.java
@@ -49,11 +49,11 @@ import org.apache.pdfbox.rendering.PDFRenderer;
 import org.jpedal.PdfDecoder;
 import org.jpedal.exception.PdfException;
 
-import com.lowagie.text.pdf.PdfReader;
-import com.sun.pdfview.PDFFile;
-import com.sun.pdfview.PDFPage;
-import com.sun.pdfview.PDFParseException;
-import com.sun.pdfview.decrypt.PDFPassword;
+import org.openpdf.renderer.PDFFile;
+import org.openpdf.renderer.PDFPage;
+import org.openpdf.renderer.PDFParseException;
+import org.openpdf.renderer.decrypt.PDFPassword;
+import org.openpdf.text.pdf.PdfReader;
 
 /**
  * Helper class for converting a page in PDF to a {@link BufferedImage} object.
@@ -88,10 +88,10 @@ public class Pdf2Image {
         for (String libname : Constants.PDF2IMAGE_LIBRARIES.split("\\s*,\\s*")) {
             if (Constants.PDF2IMAGE_JPEDAL.equals(libname)) {
                 tmpResult = getImageUsingJPedal(aPage);
-            } else if (Constants.PDF2IMAGE_PDFRENDERER.equals(libname)) {
-                tmpResult = getImageUsingPdfRenderer(aPage);
             } else if (Constants.PDF2IMAGE_PDFBOX.equals(libname)) {
                 tmpResult = getImageUsingPdfBox(aPage);
+            } else if (Constants.PDF2IMAGE_OPENPDF.equals(libname)) {
+                tmpResult = getImageUsingOpenPdfRenderer(aPage);
             }
             if (tmpResult != null)
                 break;
@@ -141,12 +141,13 @@ public class Pdf2Image {
     }
 
     /**
-     * Returns image (or null if failed) generated from given page in PDF using Sun PDFRender.
+     * Returns image (or null if failed) generated from given page in PDF using the OpenPDF renderer
+     * (actively-maintained descendant of the Sun Labs PDFRenderer).
      *
      * @param aPage page in PDF (1 based)
      * @return image or null
      */
-    public BufferedImage getImageUsingPdfRenderer(final int aPage) {
+    public BufferedImage getImageUsingOpenPdfRenderer(final int aPage) {
         BufferedImage tmpResult = null;
         RandomAccessFile raf = null;
         try {

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/types/CertificationLevel.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/types/CertificationLevel.java
@@ -31,7 +31,7 @@ package net.sf.jsignpdf.types;
 
 import static net.sf.jsignpdf.Constants.RES;
 
-import com.lowagie.text.pdf.PdfSignatureAppearance;
+import org.openpdf.text.pdf.PdfSignatureAppearance;
 
 /**
  * Enum of possible certification levels used to Sign PDF.

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/types/PdfVersion.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/types/PdfVersion.java
@@ -29,7 +29,7 @@
  */
 package net.sf.jsignpdf.types;
 
-import com.lowagie.text.pdf.PdfWriter;
+import org.openpdf.text.pdf.PdfWriter;
 
 /**
  * Enum of PDF versions
@@ -42,11 +42,11 @@ public enum PdfVersion {
                     PdfWriter.VERSION_1_6), PDF_1_7("PDF-1.7", PdfWriter.VERSION_1_7);
 
     private final String name;
-    private final char charVersion;
+    private final String stringVersion;
 
-    private PdfVersion(final String aName, char aVersion) {
+    private PdfVersion(final String aName, String aVersion) {
         name = aName;
-        charVersion = aVersion;
+        stringVersion = aVersion;
     }
 
     /**
@@ -57,15 +57,18 @@ public enum PdfVersion {
     }
 
     /**
-     * Gets version as char (representation in PdfReader and PdfWriter).
+     * Gets version as String (representation in PdfReader and PdfWriter since OpenPDF 3.x).
      */
-    public char getCharVersion() {
-        return charVersion;
+    public String getStringVersion() {
+        return stringVersion;
     }
 
-    public static PdfVersion fromCharVersion(char ver) {
+    public static PdfVersion fromStringVersion(String ver) {
+        if (ver == null) {
+            return null;
+        }
         for (PdfVersion pdfVer: PdfVersion.values()) {
-            if (pdfVer.getCharVersion() == ver) {
+            if (pdfVer.getStringVersion().equals(ver)) {
                 return pdfVer;
             }
         }

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/types/PrintRight.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/types/PrintRight.java
@@ -31,7 +31,7 @@ package net.sf.jsignpdf.types;
 
 import static net.sf.jsignpdf.Constants.RES;
 
-import com.lowagie.text.pdf.PdfWriter;
+import org.openpdf.text.pdf.PdfWriter;
 
 /**
  * Enum of possible printing rights

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/types/RenderMode.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/types/RenderMode.java
@@ -31,7 +31,7 @@ package net.sf.jsignpdf.types;
 
 import static net.sf.jsignpdf.Constants.RES;
 
-import com.lowagie.text.pdf.PdfSignatureAppearance;
+import org.openpdf.text.pdf.PdfSignatureAppearance;
 
 /**
  * Enum for visible sign rendering configuration

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/utils/FontUtils.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/utils/FontUtils.java
@@ -38,7 +38,7 @@ import net.sf.jsignpdf.Constants;
 
 import org.apache.commons.io.IOUtils;
 
-import com.lowagie.text.pdf.BaseFont;
+import org.openpdf.text.pdf.BaseFont;
 
 /**
  * Utilities for handling fonts in visible signature.

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/utils/PdfUtils.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/utils/PdfUtils.java
@@ -31,7 +31,7 @@ package net.sf.jsignpdf.utils;
 
 import java.io.IOException;
 
-import com.lowagie.text.pdf.PdfReader;
+import org.openpdf.text.pdf.PdfReader;
 
 /**
  * Utilities to handle PDFs.

--- a/jsignpdf/src/test/java/net/sf/jsignpdf/PdfExtraInfoTest.java
+++ b/jsignpdf/src/test/java/net/sf/jsignpdf/PdfExtraInfoTest.java
@@ -19,7 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.lowagie.text.exceptions.BadPasswordException;
+import org.openpdf.text.exceptions.BadPasswordException;
 
 /**
  * Tests for {@link PdfExtraInfo}, focusing on password-protected PDF handling.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
 
         <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
         <maven.assembly.plugin.version>3.8.0</maven.assembly.plugin.version>
@@ -31,7 +31,7 @@
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <openpdf.version>1.3.30</openpdf.version>
         <junit.version>4.13.2</junit.version>
-        <openjfx.version>17.0.15</openjfx.version>
+        <openjfx.version>21.0.7</openjfx.version>
     </properties>
 
     <modules>
@@ -214,7 +214,7 @@
                                 <configuration>
                                     <rules>
                                         <requireJavaVersion>
-                                            <version>[11,12)</version>
+                                            <version>[21,22)</version>
                                         </requireJavaVersion>
                                     </rules>
                                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,11 @@
         <bouncycastle.version>1.84</bouncycastle.version>
         <jsign.pkcs11.version>1.1.0</jsign.pkcs11.version>
         <jsign.jpedal.version>4.92.13</jsign.jpedal.version>
-        <pdfbox.version>2.0.27</pdfbox.version>
-        <pdf-renderer.version>140</pdf-renderer.version>
+        <pdfbox.version>2.0.36</pdfbox.version>
         <commons-io.version>2.21.0</commons-io.version>
         <commons-cli.version>1.11.0</commons-cli.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <openpdf.version>1.3.30</openpdf.version>
+        <openpdf.version>3.0.3</openpdf.version>
         <junit.version>4.13.2</junit.version>
         <openjfx.version>21.0.7</openjfx.version>
     </properties>
@@ -45,6 +44,11 @@
             <dependency>
                 <groupId>com.github.librepdf</groupId>
                 <artifactId>openpdf</artifactId>
+                <version>${openpdf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.librepdf</groupId>
+                <artifactId>openpdf-renderer</artifactId>
                 <version>${openpdf.version}</version>
             </dependency>
             <dependency>
@@ -71,11 +75,6 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.rjolly</groupId>
-                <artifactId>pdf-renderer</artifactId>
-                <version>${pdf-renderer.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -35,7 +35,7 @@ toc: false
 </div>
 
 <p class="jsp-meta">
-  Runs on Windows, macOS and Linux · Java 11+ · LGPL / MPL licensed
+  Runs on Windows, macOS and Linux · Java 21+ · LGPL / MPL licensed
 </p>
 
 <div class="jsp-hero-showcase">

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -11,7 +11,7 @@ cascade:
 
 - Download the latest release from the [GitHub releases page](https://github.com/intoolswetrust/jsignpdf/releases/latest).
 - On Windows 64-bit, pick one of the `win-x64` artifacts — the **EXE** or **MSI** installer, or the **portable ZIP**. All three bundle their own Java runtime.
-- On Linux, macOS or 32-bit Windows, download `jsignpdf-*.zip` (the platform-independent archive) and install Java 11 or newer, e.g. from [Eclipse Adoptium](https://adoptium.net/).
+- On Linux, macOS or 32-bit Windows, download `jsignpdf-*.zip` (the platform-independent archive) and install Java 21 or newer, e.g. from [Eclipse Adoptium](https://adoptium.net/).
 - Extract the archive if you chose a ZIP.
 
 ### 2. Get a keystore

--- a/website/docs/JSignPdf.adoc
+++ b/website/docs/JSignPdf.adoc
@@ -57,7 +57,7 @@ Each release provides the following artifacts:
 |Artifact |Description
 
 |`jsignpdf-${VERSION}.zip`
-|Platform-independent ZIP archive containing the JAR files (`JSignPdf.jar`, `InstallCert.jar`), a shell launcher for Linux/macOS, the documentation and the demo material. Works on any OS with Java 11 or newer installed.
+|Platform-independent ZIP archive containing the JAR files (`JSignPdf.jar`, `InstallCert.jar`), a shell launcher for Linux/macOS, the documentation and the demo material. Works on any OS with Java 21 or newer installed.
 
 |`JSignPdf-${VERSION}-win-x64.exe`
 |Windows 64-bit EXE installer. Bundles its own Java runtime, installs to _Program Files_ by default, creates Start Menu shortcuts and registers an Add/Remove Programs entry.
@@ -150,11 +150,11 @@ All four launchers share the bundled JRE -- you do **not** need to have Java ins
 
 === From the platform-independent ZIP
 
-All platforms (with Java 11 or newer installed) can run the JAR file _JSignPdf.jar_ directly. Use the following command in the directory where the application is located:
+All platforms (with Java 21 or newer installed) can run the JAR file _JSignPdf.jar_ directly. Use the following command in the directory where the application is located:
 
  $ java -jar JSignPdf.jar
 
-On Linux and macOS a convenience shell script is bundled in `bin/jsignpdf.sh` which adds the JVM options required on Java 11+ and then launches the JAR.
+On Linux and macOS a convenience shell script is bundled in `bin/jsignpdf.sh` which adds the JVM options required on Java 21+ and then launches the JAR.
 
 By default, JSignPdf opens the JavaFX graphical interface (see <<Using the JavaFX UI>>). To start the classic Swing GUI instead, set the `jsignpdf.swing` system property:
 


### PR DESCRIPTION
## Summary

Lifts the compile/runtime baseline to Java 21 and upgrades OpenPDF 1.3.30 → 3.0.3 in one hop, as laid out in the two design docs added by this PR ([`3.0.0-java21-upgrade.md`](design-doc/3.0.0-java21-upgrade.md), [`3.0.0-openpdf-upgrade.md`](design-doc/3.0.0-openpdf-upgrade.md)).

### Phase 1 — Java 21 baseline

- `maven.compiler.release` 11 → 21; release-profile enforcer range `[21,22)`.
- `openjfx` 17.0.15 → 21.0.7; `openjfx-monocle` 11.0.2 → 21.0.2.
- CI workflows (`pr-builder`, `push-snapshots`, `do-release`) switched to `java-version: 21`. The jpackage step was already on 21.
- Docs and 3.0.0 release notes now advertise Java 21+. Flatpak (`openjdk21`) and jpackage-bundled Windows installers are unaffected.

### Phase 2 — OpenPDF 3.x + preview cascade cleanup

- `openpdf` 1.3.30 → **3.0.3**, pulling in the `com.lowagie.*` → `org.openpdf.*` rename across 12 files.
- `pdfbox` 2.0.27 → **2.0.36**.
- Dropped the dead `com.github.rjolly:pdf-renderer` (Sun Labs 2007 fork) and replaced it with `com.github.librepdf:openpdf-renderer:3.0.3`, the actively-maintained descendant of the same lineage. Default `pdf2image.libraries` cascade is now `jpedal,pdfbox,openpdf`.
- API shims for OpenPDF 3.x breaking changes:
  - `PdfWriter.VERSION_*` / `PdfReader.getPdfVersion()` / `PdfStamper.createSignature(...)` switched from `char` to `String` — `types/PdfVersion` and `SignerLogic`/`UncompressPdf` adapted (`getStringVersion` / `fromStringVersion`, null-safe default).
  - `AcroFields.getSignatureNames()` → `getSignedFieldNames()`.
  - `PdfSignatureAppearance.getSignDate()` now returns `null` by default — switched to `getSignDateNullSafe()` to avoid NPE in `new PdfDate(...)`.

### What's deferred

- Phase 3 (Java 21 syntactic modernization) — separate small PRs.
- Distribution build verification (Flatpak regen, Windows installer, full manual signing matrix) — Phase 4 of the design doc. `distribution/linux/flatpak/maven-dependencies.json` still needs a full regeneration via `generate-dependencies.sh` (the rjolly pins are removed here, but openpdf 1.3.30 / pdfbox 2.0.27 pins are stale and must be refreshed before a Flatpak build).

## Test plan

- [x] \`mvn clean verify\` green on Temurin 21.0.10 — all 4 reactor modules build.
- [x] 81/81 JUnit tests pass (signing, PdfExtraInfo, JavaFX Monocle, ViewModels, translations).
- [x] \`mvn dependency:tree\` confirms `openpdf:3.0.3`, `openpdf-renderer:3.0.3`, `pdfbox:2.0.36`, no `rjolly/pdf-renderer`.
- [ ] Manual signing smoke-test matrix (Phase 4 of design doc): CLI + JavaFX GUI + Swing fallback, PKCS#11 token, LTV against Adobe / Foxit / mobile.
- [ ] Preview cascade exercised individually (`jpedal` only / `pdfbox` only / `openpdf` only).
- [ ] Flatpak offline build after regenerating `maven-dependencies.json`.
- [ ] Windows `jpackage` installer build on JDK 21.