### PR TITLE
Java 21 syntax modernization (Phase 3)

### DIFF
--- a/jsignpdf/src/main/java/net/sf/jsignpdf/Constants.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/Constants.java
@@ -52,7 +52,7 @@ import net.sf.jsignpdf.utils.ResourceProvider;
 public class Constants {
 
     static {
-        try (InputStream is = Constants.class.getClassLoader().
+        try (var is = Constants.class.getClassLoader().
                 getResourceAsStream("logging.properties")) {
             LogManager.getLogManager().readConfiguration(is);
         } catch (IOException e) {
@@ -426,10 +426,10 @@ public class Constants {
         SUPPORTED_CRITICAL_EXTENSION_OIDS = Collections.unmodifiableSet(oidSet);
 
         String version = "[UNKNOWN]";
-        try (InputStream is = Constants.class
+        try (var is = Constants.class
                 .getResourceAsStream("/META-INF/maven/com.github.kwart.jsign/jsignpdf/pom.properties")) {
             if (is != null) {
-                Properties props = new Properties();
+                var props = new Properties();
                 props.load(is);
                 if (props.containsKey("version")) {
                     version = props.getProperty("version");

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/JTextAreaHandler.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/JTextAreaHandler.java
@@ -70,7 +70,7 @@ public class JTextAreaHandler extends Handler {
         jTextArea.append(record.getLevel() + " " + record.getMessage() + NEW_LINE);
         Throwable thrown = record.getThrown();
         if (thrown != null) {
-            try (StringWriter stringWriter = new StringWriter()) {
+            try (var stringWriter = new StringWriter()) {
                 thrown.printStackTrace(new PrintWriter(stringWriter, true));
                 jTextArea.append(stringWriter.toString());
             } catch (IOException e) {

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/SignerFileChooser.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/SignerFileChooser.java
@@ -101,9 +101,8 @@ public class SignerFileChooser extends JFileChooser {
     public void setSelectedFile(File file) {
         super.setSelectedFile(file);
         // safety check
-        if (getUI() instanceof BasicFileChooserUI) {
+        if (getUI() instanceof BasicFileChooserUI tmpUi) {
             // grab the ui and set the filename
-            BasicFileChooserUI tmpUi = (BasicFileChooserUI) getUI();
             tmpUi.setFileName(file == null ? "" : file.getName());
         }
     }

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/SignerOptionsFromCmdLine.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/SignerOptionsFromCmdLine.java
@@ -255,8 +255,8 @@ public class SignerOptionsFromCmdLine extends BasicSignerOptions {
      * @return
      */
     private int getInt(Object aVal, int aDefVal) {
-        if (aVal instanceof Number) {
-            return ((Number) aVal).intValue();
+        if (aVal instanceof Number n) {
+            return n.intValue();
         }
         return aDefVal;
     }
@@ -269,8 +269,8 @@ public class SignerOptionsFromCmdLine extends BasicSignerOptions {
      * @return
      */
     private float getFloat(Object aVal, float aDefVal) {
-        if (aVal instanceof Number) {
-            return ((Number) aVal).floatValue();
+        if (aVal instanceof Number n) {
+            return n.floatValue();
         }
         return aDefVal;
     }

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/crl/CRLInfo.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/crl/CRLInfo.java
@@ -115,8 +115,8 @@ public class CRLInfo {
         LOGGER.info(RES.get("console.readingCRLs"));
         final Set<String> urls = new HashSet<String>();
         for (Certificate cert : certChain) {
-            if (cert instanceof X509Certificate) {
-                urls.addAll(getCrlUrls((X509Certificate) cert));
+            if (cert instanceof X509Certificate x509Cert) {
+                urls.addAll(getCrlUrls(x509Cert));
             }
         }
         final Set<CRL> crlSet = new HashSet<CRL>();

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/preview/Pdf2Image.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/preview/Pdf2Image.java
@@ -86,13 +86,12 @@ public class Pdf2Image {
     public BufferedImage getImageForPage(final int aPage) {
         BufferedImage tmpResult = null;
         for (String libname : Constants.PDF2IMAGE_LIBRARIES.split("\\s*,\\s*")) {
-            if (Constants.PDF2IMAGE_JPEDAL.equals(libname)) {
-                tmpResult = getImageUsingJPedal(aPage);
-            } else if (Constants.PDF2IMAGE_PDFBOX.equals(libname)) {
-                tmpResult = getImageUsingPdfBox(aPage);
-            } else if (Constants.PDF2IMAGE_OPENPDF.equals(libname)) {
-                tmpResult = getImageUsingOpenPdfRenderer(aPage);
-            }
+            tmpResult = switch (libname) {
+                case Constants.PDF2IMAGE_JPEDAL -> getImageUsingJPedal(aPage);
+                case Constants.PDF2IMAGE_PDFBOX -> getImageUsingPdfBox(aPage);
+                case Constants.PDF2IMAGE_OPENPDF -> getImageUsingOpenPdfRenderer(aPage);
+                default -> null;
+            };
             if (tmpResult != null)
                 break;
         }

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/ssl/DynamicX509TrustManager.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/ssl/DynamicX509TrustManager.java
@@ -128,8 +128,8 @@ public class DynamicX509TrustManager implements X509TrustManager {
         // acquire X509 trust manager from factory
         TrustManager tms[] = trustManagerFactory.getTrustManagers();
         for (int i = 0; i < tms.length; i++) {
-            if (tms[i] instanceof X509TrustManager) {
-                trustManager = (X509TrustManager) tms[i];
+            if (tms[i] instanceof X509TrustManager x509Tm) {
+                trustManager = x509Tm;
                 return;
             }
         }

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/utils/ConvertUtils.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/utils/ConvertUtils.java
@@ -106,10 +106,10 @@ public class ConvertUtils {
         if (anObj == null)
             return null;
         Integer tmpResult = null;
-        if (anObj instanceof Integer) {
-            tmpResult = (Integer) anObj;
-        } else if (anObj instanceof Number) {
-            tmpResult = new Integer(((Number) anObj).intValue());
+        if (anObj instanceof Integer i) {
+            tmpResult = i;
+        } else if (anObj instanceof Number n) {
+            tmpResult = new Integer(n.intValue());
         } else {
             try {
                 tmpResult = new Integer(toString(anObj));
@@ -142,10 +142,10 @@ public class ConvertUtils {
         if (anObj == null)
             return null;
         Float tmpResult = null;
-        if (anObj instanceof Float) {
-            tmpResult = (Float) anObj;
-        } else if (anObj instanceof Number) {
-            tmpResult = new Float(((Number) anObj).floatValue());
+        if (anObj instanceof Float f) {
+            tmpResult = f;
+        } else if (anObj instanceof Number n) {
+            tmpResult = new Float(n.floatValue());
         } else {
             try {
                 tmpResult = new Float(toString(anObj));
@@ -189,8 +189,8 @@ public class ConvertUtils {
         Boolean tmpResult = null;
         if (anObj == null) {
             // nothing to do
-        } else if (anObj instanceof Boolean) {
-            tmpResult = (Boolean) anObj;
+        } else if (anObj instanceof Boolean b) {
+            tmpResult = b;
         } else {
             final String tmpStr = toString(anObj);
             if ("true".equalsIgnoreCase(tmpStr) || "yes".equalsIgnoreCase(tmpStr) || "on".equalsIgnoreCase(tmpStr)) {

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/utils/KeyStoreUtils.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/utils/KeyStoreUtils.java
@@ -146,8 +146,7 @@ public class KeyStoreUtils {
                 if (aKs.isKeyEntry(tmpAlias)) {
                     final Certificate tmpCert = aKs.getCertificate(tmpAlias);
                     boolean tmpAddAlias = true;
-                    if (tmpCert instanceof X509Certificate) {
-                        final X509Certificate tmpX509 = (X509Certificate) tmpCert;
+                    if (tmpCert instanceof X509Certificate tmpX509) {
                         if (checkValidity) {
                             try {
                                 tmpX509.checkValidity();

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/utils/ResourceProvider.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/utils/ResourceProvider.java
@@ -76,24 +76,20 @@ public class ResourceProvider {
     public void setLabelAndMnemonic(final JComponent aComponent, final String aKey) {
         final String tmpLabelText = get(aKey);
         final int tmpMnemIndex = getMnemonicIndex(aKey);
-        if (aComponent instanceof JLabel) {
-            final JLabel tmpLabel = (JLabel) aComponent;
+        if (aComponent instanceof JLabel tmpLabel) {
             tmpLabel.setText(tmpLabelText);
             if (tmpMnemIndex > -1) {
                 tmpLabel.setDisplayedMnemonic(tmpLabelText.toLowerCase().charAt(tmpMnemIndex));
                 tmpLabel.setDisplayedMnemonicIndex(tmpMnemIndex);
             }
-        } else if (aComponent instanceof AbstractButton) {
+        } else if (aComponent instanceof AbstractButton tmpBtn) {
             // handles Buttons, Checkboxes and Radiobuttons
-            final AbstractButton tmpBtn = (AbstractButton) aComponent;
             tmpBtn.setText(tmpLabelText);
             if (tmpMnemIndex > -1) {
                 tmpBtn.setMnemonic(tmpLabelText.toLowerCase().charAt(tmpMnemIndex));
             }
-        } else if (aComponent instanceof JPanel) {
-            final JPanel panel = (JPanel) aComponent;
-            if (panel.getBorder() instanceof TitledBorder) {
-                final TitledBorder titledBorder = (TitledBorder) panel.getBorder();
+        } else if (aComponent instanceof JPanel panel) {
+            if (panel.getBorder() instanceof TitledBorder titledBorder) {
                 titledBorder.setTitle(tmpLabelText);
             }
         } else {


### PR DESCRIPTION
## Summary

Internal-only syntactic cleanup on top of #342, following Phase 3 of [`design-doc/3.0.0-java21-upgrade.md`](design-doc/3.0.0-java21-upgrade.md). No behavior change, no API change.

- **Pattern matching for `instanceof`** (10 sites across 7 files): `SignerFileChooser`, `SignerOptionsFromCmdLine`, `utils/ResourceProvider` (JLabel / AbstractButton / JPanel / TitledBorder), `utils/KeyStoreUtils`, `ssl/DynamicX509TrustManager`, `crl/CRLInfo`, `utils/ConvertUtils`. Drops the redundant explicit casts.
- **Switch expression** in `preview/Pdf2Image#getImageForPage` — the if/else chain over `PDF2IMAGE_*` constants collapses into a `switch` with arrow labels now that the cascade includes `openpdf`.
- **`var` (targeted)** on three try-with-resources sites (`Constants.java` x2, `JTextAreaHandler.java`) and one `Properties` local. Left explicit types everywhere they carry real documentation value.

### Not adopted (design-doc §5.2 / §5.3)

- `.toList()` — no `Collectors.toList()` call sites exist in the codebase; the design doc overstated that one.
- **Records** — `types/PageInfo` is the only clean value-type candidate, but converting would force renaming `getWidth()/getHeight()` → `width()/height()` across ~15 call sites including tests; that's a separate API-rename theme and deferred. `types/RelRect` has `PropertyChangeSupport` so it's disqualified per design-doc guidance.
- Text blocks, sealed types, virtual threads, FFM/Vector API — no fit.

## Test plan

- [x] \`mvn clean verify\` green on Temurin 21.0.10 — all 4 reactor modules build.
- [x] 81/81 JUnit tests pass (signing, PdfExtraInfo, JavaFX Monocle, ViewModels, translations).