### PR TITLE
Improve passwords handling when provided from stdin (related to #7)

### DIFF
--- a/jsignpdf/src/main/java/net/sf/jsignpdf/SignerOptionsFromCmdLine.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/SignerOptionsFromCmdLine.java
@@ -34,6 +34,7 @@ import static net.sf.jsignpdf.Constants.*;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.Proxy;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -263,39 +264,27 @@ public class SignerOptionsFromCmdLine extends BasicSignerOptions {
         final boolean stdinEnabled = line.hasOption(ARG_ENABLE_STDIN_PWDS_LONG);
         final boolean quiet = line.hasOption(ARG_QUIET);
 
-        final String[][] slots = {
-                { ARG_KS_PWD, ARG_KS_PWD_LONG },
-                { ARG_KEY_PWD, ARG_KEY_PWD_LONG },
-                { ARG_PWD_OWNER, ARG_PWD_OWNER_LONG },
-                { ARG_PWD_USER, ARG_PWD_USER_LONG },
-                { ARG_TSA_CERT_PWD, ARG_TSA_CERT_PWD_LONG },
-                { ARG_TSA_PWD, ARG_TSA_PWD_LONG },
-        };
-        @SuppressWarnings("unchecked")
-        final Consumer<String>[] setters = new Consumer[] {
-                (Consumer<String>) this::setKsPasswd,
-                (Consumer<String>) this::setKeyPasswd,
-                (Consumer<String>) this::setPdfOwnerPwd,
-                (Consumer<String>) this::setPdfUserPwd,
-                (Consumer<String>) this::setTsaCertFilePwd,
-                (Consumer<String>) this::setTsaPasswd,
-        };
+        final List<PwdSlot> slots = List.of(
+                new PwdSlot(ARG_KS_PWD, ARG_KS_PWD_LONG, this::setKsPasswd),
+                new PwdSlot(ARG_KEY_PWD, ARG_KEY_PWD_LONG, this::setKeyPasswd),
+                new PwdSlot(ARG_PWD_OWNER, ARG_PWD_OWNER_LONG, this::setPdfOwnerPwd),
+                new PwdSlot(ARG_PWD_USER, ARG_PWD_USER_LONG, this::setPdfUserPwd),
+                new PwdSlot(ARG_TSA_CERT_PWD, ARG_TSA_CERT_PWD_LONG, this::setTsaCertFilePwd),
+                new PwdSlot(ARG_TSA_PWD, ARG_TSA_PWD_LONG, this::setTsaPasswd));
 
         int total = 0;
-        for (String[] slot : slots) {
-            if (line.hasOption(slot[0]) && STDIN_PWD_SENTINEL.equals(line.getOptionValue(slot[0]))) {
+        for (PwdSlot slot : slots) {
+            if (line.hasOption(slot.shortArg()) && STDIN_PWD_SENTINEL.equals(line.getOptionValue(slot.shortArg()))) {
                 total++;
             }
         }
 
         int index = 0;
-        for (int i = 0; i < slots.length; i++) {
-            final String shortArg = slots[i][0];
-            final String longArg = slots[i][1];
-            if (!line.hasOption(shortArg)) {
+        for (PwdSlot slot : slots) {
+            if (!line.hasOption(slot.shortArg())) {
                 continue;
             }
-            final String raw = line.getOptionValue(shortArg);
+            final String raw = line.getOptionValue(slot.shortArg());
             if (STDIN_PWD_SENTINEL.equals(raw)) {
                 if (stdinEnabled) {
                     index++;
@@ -303,24 +292,27 @@ public class SignerOptionsFromCmdLine extends BasicSignerOptions {
                         if (passwordReader == null) {
                             passwordReader = StdinPasswordReader.systemDefault(quiet);
                         }
-                        char[] chars = passwordReader.readNext(longArg, index, total);
-                        setters[i].accept(new String(chars));
+                        char[] chars = passwordReader.readNext(slot.longArg(), index, total);
+                        slot.setter().accept(new String(chars));
                     } catch (IOException ioe) {
                         throw new ParseException(ioe.getMessage());
                     }
                 } else {
                     if (!quiet) {
                         PrintStream w = warningOut != null ? warningOut : System.err;
-                        w.println("[jsignpdf] Warning: --" + longArg + " value is '-'. Did you mean to pass --"
+                        w.println("[jsignpdf] Warning: --" + slot.longArg() + " value is '-'. Did you mean to pass --"
                                 + ARG_ENABLE_STDIN_PWDS_LONG
                                 + " to read it from stdin? Using '-' as the literal password.");
                     }
-                    setters[i].accept(raw);
+                    slot.setter().accept(raw);
                 }
             } else {
-                setters[i].accept(raw);
+                slot.setter().accept(raw);
             }
         }
+    }
+
+    private record PwdSlot(String shortArg, String longArg, Consumer<String> setter) {
     }
 
     /**

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/SignerOptionsFromCmdLine.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/SignerOptionsFromCmdLine.java
@@ -300,9 +300,7 @@ public class SignerOptionsFromCmdLine extends BasicSignerOptions {
                 } else {
                     if (!quiet) {
                         PrintStream w = warningOut != null ? warningOut : System.err;
-                        w.println("[jsignpdf] Warning: --" + slot.longArg() + " value is '-'. Did you mean to pass --"
-                                + ARG_ENABLE_STDIN_PWDS_LONG
-                                + " to read it from stdin? Using '-' as the literal password.");
+                        w.println(RES.get("console.stdinSentinelWarning", slot.longArg(), ARG_ENABLE_STDIN_PWDS_LONG));
                     }
                     slot.setter().accept(raw);
                 }

--- a/jsignpdf/src/main/resources/net/sf/jsignpdf/translations/messages.properties
+++ b/jsignpdf/src/main/resources/net/sf/jsignpdf/translations/messages.properties
@@ -64,6 +64,7 @@ console.settingTsaHashAlg=Setting TSA hash algorithm: {0}
 console.settingTsaPolicy=Setting TSA policy OID: {0}
 console.skippingSigning=File validation failed, check your PDF paths. Skipping sign proccess.
 console.starting=Starting JSignPdf
+console.stdinSentinelWarning=[jsignpdf] Warning: --{0} value matches the stdin sentinel, but --{1} was not provided. Using it as a literal password.
 console.unsupportedEncryptionType=Unsupported encryption type.
 console.updateVersion=Updating PDF version info 1.{0} -> 1.{1}
 #console.updateVersionNotPossibleInAppendMode=Choosen configuration requires PDF version update, but it's not possible in the "append" signature mode.

--- a/jsignpdf/src/test/java/net/sf/jsignpdf/SignerOptionsFromCmdLineTest.java
+++ b/jsignpdf/src/test/java/net/sf/jsignpdf/SignerOptionsFromCmdLineTest.java
@@ -202,6 +202,31 @@ public class SignerOptionsFromCmdLineTest {
     }
 
     @Test
+    public void dashFromPropertiesFile_isNotReinterpretedAsSentinel() throws Exception {
+        // Per design-doc §3.5: a '-' set from a properties file is not a sentinel.
+        // Simulate loadOptions() having set the password before CLI parse. With no matching
+        // password option on the CLI, the resolver must leave the props-loaded value alone —
+        // even when --enable-stdin-passwords is set, and the reader must not be consulted.
+        Fixture f = new Fixture("POISON\n");
+        f.opts.setKsPasswd("-");
+        f.opts.setCmdLine(new String[] { "--enable-stdin-passwords" });
+        f.opts.loadCmdLine();
+        assertEquals("-", new String(f.opts.getKsPasswd()));
+        assertTrue(f.warnings().isEmpty());
+    }
+
+    @Test
+    public void cliSentinelOverridesPropertiesFileValue() throws Exception {
+        // Per design-doc §3.5: when a password is set by a properties file and the same option
+        // is also given on the CLI as the stdin sentinel, the CLI wins and stdin is consulted.
+        Fixture f = new Fixture("from-stdin\n");
+        f.opts.setKsPasswd("from-props");
+        f.opts.setCmdLine(new String[] { "--enable-stdin-passwords", "-ksp", "-" });
+        f.opts.loadCmdLine();
+        assertEquals("from-stdin", new String(f.opts.getKsPasswd()));
+    }
+
+    @Test
     public void parseFailureForUnknownOption_doesNotTouchReader() {
         // Sanity check: commons-cli throws before we reach the resolver, reader is untouched.
         Fixture f = new Fixture("POISON\n");


### PR DESCRIPTION
## Summary

Follow-up to #357, addressing items surfaced by a post-merge review of the stdin-password feature.

1. **Decouple the password-slot table.** The resolver in `SignerOptionsFromCmdLine` used two parallel arrays (`String[][] slots` + `Consumer[] setters`) coupled by index; reordering one without the other would have silently assigned a password to the wrong field. Replaced with a single `List<PwdSlot>` of records, which also lets the `@SuppressWarnings("unchecked")` go away.
2. **Cover §3.5 of the design doc with tests.** The design explicitly says a `-` coming from a properties file must not be reinterpreted as the stdin sentinel, and that a CLI `-ksp -` with the flag overrides a props-loaded value. Neither path had an assertion. Two integration tests added.
3. **i18n for the "literal dash" warning.** The warning emitted when `-` is given without `--enable-stdin-passwords` was hardcoded English. Moved to a new resource key `console.stdinSentinelWarning` (English bundle only — other locales follow via Weblate, per `AGENTS.md`). Also reworded so the literal value is no longer echoed back at the user.

## Changes

- `SignerOptionsFromCmdLine.java` — record-based slot list; warning goes through `RES.get(...)`.
- `messages.properties` — new `console.stdinSentinelWarning` key with `{0}` = option long name, `{1}` = flag long name.
- `SignerOptionsFromCmdLineTest.java` — two new tests:
  - `dashFromPropertiesFile_isNotReinterpretedAsSentinel`
  - `cliSentinelOverridesPropertiesFileValue`

## Test plan

- [x] `mvn -pl jsignpdf test -Dtest=StdinPasswordReaderTest,SignerOptionsFromCmdLineTest` — 25/25 green (17 in `SignerOptionsFromCmdLineTest`, including the two new ones; 8 in `StdinPasswordReaderTest`).