### PR TITLE
Change the default values in the new UI

### DIFF
--- a/distribution/doc/release-notes/3.0.0.md
+++ b/distribution/doc/release-notes/3.0.0.md
@@ -33,6 +33,9 @@ packaging.
   canonical order printed on stderr before each read. Avoids leaking
   secrets to `/proc/<pid>/cmdline` and shell history.
 - "Reset Settings" action added to the JavaFX UI.
+- _Append signature_ and _Store passwords_ checkboxes are now checked by
+  default on a fresh install (previously both defaulted to unchecked).
+  Existing preferences are unchanged.
 - New and updated translations (Czech, German, French, Spanish, Slovak,
   Portuguese, Croatian, Simplified Chinese, Traditional Chinese, and
   more — thanks to all Weblate contributors).

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/BasicSignerOptions.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/BasicSignerOptions.java
@@ -79,7 +79,7 @@ public class BasicSignerOptions {
     private CertificationLevel certLevel;
     private HashAlgorithm hashAlgorithm;
 
-    protected boolean storePasswords;
+    protected boolean storePasswords = Constants.DEFVAL_STOREPWD;
 
     // options from rights dialog
     private PrintRight rightPrinting;
@@ -148,7 +148,7 @@ public class BasicSignerOptions {
         setReason(props.getProperty(Constants.PROPERTY_REASON));
         setLocation(props.getProperty(Constants.PROPERTY_LOCATION));
         setContact(props.getProperty(Constants.PROPERTY_CONTACT));
-        setAppend(props.getAsBool(Constants.PROPERTY_APPEND));
+        setAppend(props.getAsBool(Constants.PROPERTY_APPEND, Constants.DEFVAL_APPEND));
         // backward compatibility
         setPdfEncryption(props.getProperty(Constants.PROPERTY_PDF_ENCRYPTION));
         if (pdfEncryption == null && props.getAsBool(Constants.PROPERTY_ENCRYPTED_PDF)) {
@@ -209,7 +209,7 @@ public class BasicSignerOptions {
         setProxyPort(props.getAsInt(Constants.PROPERTY_PROXY_PORT, Constants.DEFVAL_PROXY_PORT));
 
         // passwords
-        storePasswords = props.getAsBool(Constants.PROPERTY_STOREPWD);
+        storePasswords = props.getAsBool(Constants.PROPERTY_STOREPWD, Constants.DEFVAL_STOREPWD);
         final String tmpHome = getDecrypted(Constants.EPROPERTY_USERHOME);
         final boolean tmpPasswords = storePasswords && Constants.USER_HOME != null && Constants.USER_HOME.equals(tmpHome);
         if (tmpPasswords) {

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/Constants.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/Constants.java
@@ -240,6 +240,8 @@ public class Constants {
 
     public static final boolean DEFVAL_APPEND = toBoolean(true);
 
+    public static final boolean DEFVAL_STOREPWD = toBoolean(true);
+
     public static final int DEFVAL_KEY_INDEX = 0;
     public static final int DEFVAL_PAGE = 1;
     public static final float DEFVAL_LLX = 0f;

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/fx/viewmodel/SigningOptionsViewModel.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/fx/viewmodel/SigningOptionsViewModel.java
@@ -35,7 +35,7 @@ public class SigningOptionsViewModel {
     private final StringProperty keyAlias = new SimpleStringProperty();
     private final IntegerProperty keyIndex = new SimpleIntegerProperty(Constants.DEFVAL_KEY_INDEX);
     private final StringProperty keyPassword = new SimpleStringProperty();
-    private final BooleanProperty storePasswords = new SimpleBooleanProperty(false);
+    private final BooleanProperty storePasswords = new SimpleBooleanProperty(Constants.DEFVAL_STOREPWD);
 
     // File settings
     private final StringProperty outFile = new SimpleStringProperty();
@@ -261,7 +261,7 @@ public class SigningOptionsViewModel {
         keyAlias.set(null);
         keyIndex.set(Constants.DEFVAL_KEY_INDEX);
         keyPassword.set(null);
-        storePasswords.set(false);
+        storePasswords.set(Constants.DEFVAL_STOREPWD);
 
         // File & metadata
         outFile.set(null);

--- a/jsignpdf/src/test/java/net/sf/jsignpdf/BasicSignerOptionsTest.java
+++ b/jsignpdf/src/test/java/net/sf/jsignpdf/BasicSignerOptionsTest.java
@@ -3,6 +3,7 @@ package net.sf.jsignpdf;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 import java.net.Proxy;
 
@@ -12,6 +13,7 @@ import net.sf.jsignpdf.types.PDFEncryption;
 import net.sf.jsignpdf.types.PrintRight;
 import net.sf.jsignpdf.types.RenderMode;
 import net.sf.jsignpdf.types.ServerAuthentication;
+import net.sf.jsignpdf.utils.PropertyProvider;
 import org.junit.Test;
 
 /**
@@ -172,6 +174,51 @@ public class BasicSignerOptionsTest {
         assertEquals(original.getProxyType(), copy.getProxyType());
         assertEquals(original.getProxyHost(), copy.getProxyHost());
         assertEquals(original.getProxyPort(), copy.getProxyPort());
+    }
+
+    /**
+     * Both field defaults must be true so the JavaFX UI shows Store passwords
+     * and Append signature as checked on a fresh install.
+     */
+    @Test
+    public void defaultFieldValues_appendAndStorePasswordsTrue() {
+        BasicSignerOptions opts = new BasicSignerOptions();
+        assertTrue("append field defaults to DEFVAL_APPEND", opts.isAppend());
+        assertTrue("storePasswords field defaults to DEFVAL_STOREPWD", opts.isStorePasswords());
+    }
+
+    /**
+     * When loadOptions() runs against an empty properties store (fresh install
+     * or after "Reset Settings"), the missing keys must fall back to the
+     * DEFVAL_* constants rather than silently becoming false.
+     */
+    @Test
+    public void loadOptions_noStoredProps_appendAndStorePasswordsDefaultTrue() {
+        PropertyProvider.getInstance().clear();
+        BasicSignerOptions opts = new BasicSignerOptions();
+        opts.loadOptions();
+        assertTrue("append should default to true when no property is stored", opts.isAppend());
+        assertTrue("storePasswords should default to true when no property is stored",
+                opts.isStorePasswords());
+    }
+
+    /**
+     * Explicit false values persisted in the properties must still be honoured
+     * — the new defaults only apply when the key is absent.
+     */
+    @Test
+    public void loadOptions_storedFalseValuesArePreserved() {
+        PropertyProvider.getInstance().clear();
+        PropertyProvider.getInstance().setProperty(Constants.PROPERTY_APPEND, false);
+        PropertyProvider.getInstance().setProperty(Constants.PROPERTY_STOREPWD, false);
+        try {
+            BasicSignerOptions opts = new BasicSignerOptions();
+            opts.loadOptions();
+            assertEquals("append must reflect stored false", false, opts.isAppend());
+            assertEquals("storePasswords must reflect stored false", false, opts.isStorePasswords());
+        } finally {
+            PropertyProvider.getInstance().clear();
+        }
     }
 
     @Test

--- a/jsignpdf/src/test/java/net/sf/jsignpdf/fx/viewmodel/SigningOptionsViewModelTest.java
+++ b/jsignpdf/src/test/java/net/sf/jsignpdf/fx/viewmodel/SigningOptionsViewModelTest.java
@@ -161,6 +161,19 @@ public class SigningOptionsViewModelTest {
                 opts.isCrlEnabledX());
     }
 
+    /**
+     * On a fresh install (no persisted preferences) the JavaFX UI must show
+     * Store passwords and Append signature as checked by default.
+     */
+    @Test
+    public void testInitialDefaults_storePasswordsAndAppendChecked() {
+        SigningOptionsViewModel vm = new SigningOptionsViewModel();
+        assertTrue("storePasswords should default to true", vm.storePasswordsProperty().get());
+        assertTrue("append should default to true", vm.appendProperty().get());
+        assertEquals("DEFVAL_STOREPWD is expected to be true", true, Constants.DEFVAL_STOREPWD);
+        assertEquals("DEFVAL_APPEND is expected to be true", true, Constants.DEFVAL_APPEND);
+    }
+
     @Test
     public void testResetToDefaults_clearsAllProperties() {
         SigningOptionsViewModel vm = new SigningOptionsViewModel();
@@ -169,7 +182,7 @@ public class SigningOptionsViewModelTest {
         vm.ksPasswordProperty().set("secret");
         vm.keyAliasProperty().set("mykey");
         vm.keyIndexProperty().set(5);
-        vm.storePasswordsProperty().set(true);
+        vm.storePasswordsProperty().set(!Constants.DEFVAL_STOREPWD);
         vm.outFileProperty().set("/tmp/output.pdf");
         vm.appendProperty().set(!Constants.DEFVAL_APPEND);
         vm.signerNameProperty().set("Test Signer");
@@ -202,7 +215,7 @@ public class SigningOptionsViewModelTest {
         assertNull("ksPassword", vm.ksPasswordProperty().get());
         assertNull("keyAlias", vm.keyAliasProperty().get());
         assertEquals("keyIndex", Constants.DEFVAL_KEY_INDEX, vm.keyIndexProperty().get());
-        assertFalse("storePasswords", vm.storePasswordsProperty().get());
+        assertEquals("storePasswords", Constants.DEFVAL_STOREPWD, vm.storePasswordsProperty().get());
         assertNull("outFile", vm.outFileProperty().get());
         assertEquals("append", Constants.DEFVAL_APPEND, vm.appendProperty().get());
         assertNull("signerName", vm.signerNameProperty().get());

--- a/website/docs/JSignPdf.adoc
+++ b/website/docs/JSignPdf.adoc
@@ -676,7 +676,7 @@ The reason, location, and contact fields provide additional information about th
 
 ==== Append signature
 
-JSignPdf can work in two signing modes. It replaces existing signatures with the new ones by default. If you enable the _Append signature_ option, the new one will be appended and the old signatures will stay unchanged. _*This option is disabled for encrypted documents.*_
+JSignPdf can work in two signing modes. When _Append signature_ is enabled, the new signature is appended and any previously-existing signatures stay unchanged; when it is disabled, existing signatures are replaced. The GUI enables _Append signature_ by default; on the CLI the default is replace (pass `-a` to append). _*This option is disabled for encrypted documents.*_
 
 ==== Certification level
 
@@ -693,7 +693,7 @@ You can choose which hash function will be used for the signature. Available alg
 
 ==== Remember passwords
 
-JSignPdf stores filled information when you are exiting the application, so it's present when you run it the next time. Passwords are not stored by default, but you can allow them by enabling the _Remember passwords_ option.
+JSignPdf stores filled information when you are exiting the application, so it's present when you run it the next time. Passwords are stored (encrypted) when the _Remember passwords_ option (labelled _Store passwords_ in the JavaFX GUI) is enabled. The option is enabled by default; uncheck it if you prefer to re-enter passwords on every launch.
 
 _*Even if the password is stored in the encrypted form, we do not recommend storing passwords if your computer is used by more users!*_
 


### PR DESCRIPTION
## Summary

- _Append signature_ and _Store passwords_ checkboxes in the JavaFX UI are now checked by default on fresh installs. Previously both defaulted to unchecked, despite `DEFVAL_APPEND=true` existing in `Constants`.
- Root cause: `BasicSignerOptions.loadOptions()` called `getAsBool(key)` without a default, so missing keys silently resolved to `false` and overrode the field's initial value. Fixed by passing `DEFVAL_APPEND` / new `DEFVAL_STOREPWD` as fallbacks.
- CLI behavior is unaffected: the `-a` flag always overrides append, and `storePasswords` is not used by the CLI flows.
- Users with existing `~/.JSignPdf` preferences keep their saved values — both keys are always persisted by `storeOptions()`, so only truly fresh installs (or post "Reset Settings") see the new defaults.

## Test plan

- [x] New unit tests in `BasicSignerOptionsTest`: default field values, `loadOptions()` with empty props, explicit-false preserved.
- [x] `SigningOptionsViewModelTest`: new fresh-VM defaults test; updated `resetToDefaults` expectation for `storePasswords`.
- [x] `mvn -pl jsignpdf test` — 110 tests pass.
- [ ] Manual smoke check: launch JavaFX UI with no `~/.JSignPdf`; verify both checkboxes start checked.
- [ ] Manual smoke check: uncheck both, close, relaunch; verify the unchecked state is restored.

## Docs

- `website/docs/JSignPdf.adoc` — Append signature and Remember passwords sections updated.
- `distribution/doc/release-notes/3.0.0.md` — bullet added.