### PR TITLE
Release Flatpak bundle (workaround as the Flathub submission is waiting for approval)

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -136,6 +136,7 @@ jobs:
   linux-flatpak:
     needs: do-release
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       VERSION: ${{ needs.do-release.outputs.version }}
     steps:
@@ -150,33 +151,47 @@ jobs:
         name: jsignpdf-linux-assets
         path: linux-assets
 
+    - name: Cache Flatpak SDK
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/share/flatpak
+        key: flatpak-sdk-25.08
+
     - name: Install Flatpak and build tools
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y flatpak flatpak-builder
-        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install -y --noninteractive flathub \
+        flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        # SDK version must match runtime-version in distribution/linux/flatpak/io.github.intoolswetrust.JSignPdf.yaml
+        flatpak install --user -y --noninteractive flathub \
           org.freedesktop.Platform//25.08 \
           org.freedesktop.Sdk//25.08 \
           org.freedesktop.Sdk.Extension.openjdk21//25.08
 
     - name: Patch manifest to use local zip
       run: |
+        set -euo pipefail
+        MANIFEST=distribution/linux/flatpak/io.github.intoolswetrust.JSignPdf.yaml
         ZIP_NAME=jsignpdf-${VERSION}.zip
         SHA256=$(sha256sum "linux-assets/${ZIP_NAME}" | awk '{print $1}')
         cp "linux-assets/${ZIP_NAME}" distribution/linux/flatpak/
         sed -i \
           "s|        url: https://downloads\.sourceforge\.net.*\.zip|        path: ${ZIP_NAME}|" \
-          distribution/linux/flatpak/io.github.intoolswetrust.JSignPdf.yaml
+          "${MANIFEST}"
+        grep -q "path: ${ZIP_NAME}" "${MANIFEST}" \
+          || { echo "::error::URL sed patch did not match — check manifest indentation"; exit 1; }
         sed -i \
           "s|sha256: [a-f0-9]\{64\}|sha256: ${SHA256}|" \
-          distribution/linux/flatpak/io.github.intoolswetrust.JSignPdf.yaml
+          "${MANIFEST}"
+        grep -q "sha256: ${SHA256}" "${MANIFEST}" \
+          || { echo "::error::sha256 sed patch did not match"; exit 1; }
 
     - name: Build Flatpak bundle
       run: |
+        set -euo pipefail
         BUNDLE_NAME=JSignPdf-${VERSION}-linux-x86_64.flatpak
         cd distribution/linux/flatpak
-        flatpak-builder --repo=flatpak-repo --force-clean --disable-rofiles-fuse build-dir \
+        flatpak-builder --user --repo=flatpak-repo --force-clean --disable-rofiles-fuse build-dir \
           io.github.intoolswetrust.JSignPdf.yaml
         flatpak build-bundle flatpak-repo "${BUNDLE_NAME}" \
           io.github.intoolswetrust.JSignPdf
@@ -220,6 +235,7 @@ jobs:
         path: release-assets/JSignPdf-${{ needs.do-release.outputs.version }}
 
     - name: Download Flatpak bundle
+      if: needs.linux-flatpak.outcome == 'success'
       uses: actions/download-artifact@v8
       with:
         name: jsignpdf-flatpak-assets

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -133,8 +133,66 @@ jobs:
         if-no-files-found: error
         retention-days: 1
 
+  linux-flatpak:
+    needs: do-release
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.do-release.outputs.version }}
+    steps:
+    - name: Checkout release tag
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ needs.do-release.outputs.tag }}
+
+    - name: Download Linux assets
+      uses: actions/download-artifact@v8
+      with:
+        name: jsignpdf-linux-assets
+        path: linux-assets
+
+    - name: Install Flatpak and build tools
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y flatpak flatpak-builder
+        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        sudo flatpak install -y --noninteractive flathub \
+          org.freedesktop.Platform//25.08 \
+          org.freedesktop.Sdk//25.08 \
+          org.freedesktop.Sdk.Extension.openjdk21//25.08
+
+    - name: Patch manifest to use local zip
+      run: |
+        ZIP_NAME=jsignpdf-${VERSION}.zip
+        SHA256=$(sha256sum "linux-assets/${ZIP_NAME}" | awk '{print $1}')
+        cp "linux-assets/${ZIP_NAME}" distribution/linux/flatpak/
+        sed -i \
+          "s|        url: https://downloads\.sourceforge\.net.*\.zip|        path: ${ZIP_NAME}|" \
+          distribution/linux/flatpak/io.github.intoolswetrust.JSignPdf.yaml
+        sed -i \
+          "s|sha256: [a-f0-9]\{64\}|sha256: ${SHA256}|" \
+          distribution/linux/flatpak/io.github.intoolswetrust.JSignPdf.yaml
+
+    - name: Build Flatpak bundle
+      run: |
+        BUNDLE_NAME=JSignPdf-${VERSION}-linux-x86_64.flatpak
+        cd distribution/linux/flatpak
+        flatpak-builder --repo=flatpak-repo --force-clean --disable-rofiles-fuse build-dir \
+          io.github.intoolswetrust.JSignPdf.yaml
+        flatpak build-bundle flatpak-repo "${BUNDLE_NAME}" \
+          io.github.intoolswetrust.JSignPdf
+        mkdir -p upload
+        mv "${BUNDLE_NAME}" upload/
+
+    - name: Stage Flatpak bundle for publish job
+      uses: actions/upload-artifact@v7
+      with:
+        name: jsignpdf-flatpak-assets
+        path: distribution/linux/flatpak/upload/*
+        if-no-files-found: error
+        retention-days: 1
+
   publish-release:
-    needs: [do-release, windows-installers]
+    needs: [do-release, windows-installers, linux-flatpak]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -159,6 +217,12 @@ jobs:
       uses: actions/download-artifact@v8
       with:
         name: jsignpdf-windows-assets
+        path: release-assets/JSignPdf-${{ needs.do-release.outputs.version }}
+
+    - name: Download Flatpak bundle
+      uses: actions/download-artifact@v8
+      with:
+        name: jsignpdf-flatpak-assets
         path: release-assets/JSignPdf-${{ needs.do-release.outputs.version }}
 
     - name: List staged assets


### PR DESCRIPTION
Relates to #307 

Adds a `linux-flatpak` job to the release workflow that builds and publishes a self-contained Flatpak bundle (`JSignPdf-<version>-linux-x86_64.flatpak`) alongside the existing Windows and Linux zip assets.

**How it works:**

- Runs in parallel with `windows-installers`, both gated on `do-release`
- Downloads the already-built zip artifact from the `do-release` job
- Installs Flatpak, flatpak-builder, and the Freedesktop SDK 25.08 + OpenJDK21 extension
- Patches `io.github.intoolswetrust.JSignPdf.yaml` to reference the local zip (replaces the SourceForge URL and recomputes the sha256) so no network download is needed for the app source
- Exports the bundle via `flatpak build-bundle`
- `publish-release` downloads the bundle and includes it in both the SourceForge upload and the GitHub release

**Context:** The Flathub submission ([flathub/flathub#8338](https://github.com/flathub/flathub/pull/8338)) is still pending review. This provides a directly installable Flatpak bundle for Linux users in the meantime.