### PR TITLE
Fixes for #397

### DIFF
--- a/jsignpdf/src/main/java/net/sf/jsignpdf/fx/JSignPdfApp.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/fx/JSignPdfApp.java
@@ -4,9 +4,11 @@ import java.util.ResourceBundle;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import net.sf.jsignpdf.BasicSignerOptions;
 import net.sf.jsignpdf.Constants;
@@ -51,5 +53,10 @@ public class JSignPdfApp extends Application {
         primaryStage.setOnCloseRequest(event -> controller.storeAndCleanup());
 
         primaryStage.show();
+
+        Rectangle2D visualBounds = Screen.getPrimary().getVisualBounds();
+        if (primaryStage.getWidth() > visualBounds.getWidth() || primaryStage.getHeight() > visualBounds.getHeight()) {
+            primaryStage.setMaximized(true);
+        }
     }
 }

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/fx/viewmodel/SigningOptionsViewModel.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/fx/viewmodel/SigningOptionsViewModel.java
@@ -236,8 +236,8 @@ public class SigningOptionsViewModel {
         rightModifyAnnotations.set(opts.isRightModifyAnnotations());
         rightModifyContents.set(opts.isRightModifyContents());
 
-        tsaEnabled.set(opts.isTimestamp());
         tsaUrl.set(opts.getTsaUrl());
+        tsaEnabled.set(opts.isTimestamp());
         tsaServerAuthn.set(opts.getTsaServerAuthn());
         tsaUser.set(opts.getTsaUser());
         tsaPassword.set(opts.getTsaPasswd());


### PR DESCRIPTION
Fixes issues 1 and 2 from #397.

- **Window too tall for 1366×768 screens**: after the window is shown, compare its size against the primary screen's visual bounds (excluding taskbar). If either dimension overflows, maximize the window automatically.
- **TSA panel expands on relaunch**: `syncFromOptions` was setting `tsaEnabled` before `tsaUrl`, so the listener that opens the TSA accordion (intended only for when the user enables TSA without a URL) fired during startup with an empty URL. Swapping the two assignment lines fixes the ordering.